### PR TITLE
Rename

### DIFF
--- a/Makefile.defaults
+++ b/Makefile.defaults
@@ -42,6 +42,7 @@ FSRC = pfasst.f90 \
        pf_hooks.f90 \
        pf_interpolate.f90 \
        pf_parallel.f90 \
+       pf_parareal.f90 \
        pf_parallel_oc.f90 \
        pf_pfasst.f90 \
        pf_quadrature.f90 \

--- a/Makefile.external
+++ b/Makefile.external
@@ -14,6 +14,10 @@ $(FFTW3).tar.gz:
 	wget http://fftw.org/$(FFTW3).tar.gz
 
 
+libnpy:
+	git clone https://github.com/kovalp/libnpy.git
+	cd libnpy && cp archs/arch.inc.gcc arch.inc &&	make INSTALL_FLAVOR=fortran_mod
+
 #
 # hdf5
 #

--- a/Tutorials/EX1_Dahlquist/src/main.f90
+++ b/Tutorials/EX1_Dahlquist/src/main.f90
@@ -37,7 +37,7 @@ contains
     !>  Local variables
     type(pf_pfasst_t) :: pf       !<  the main pfasst structure
     type(pf_comm_t)   :: comm     !<  the communicator (here it is mpi)
-    type(ndarray)     :: y_0      !<  the initial condition
+    type(pf_ndarray_t):: y_0      !<  the initial condition
     character(256)    :: pf_fname   !<  file name for input of PFASST parameters
 
     integer           ::  l   !  loop variable over levels
@@ -57,7 +57,7 @@ contains
        allocate(my_level_t::pf%levels(l)%ulevel)
 
        !>  Allocate the user specific data constructor
-       allocate(ndarray_factory::pf%levels(l)%ulevel%factory)
+       allocate(pf_ndarray_factory_t::pf%levels(l)%ulevel%factory)
 
        !>  Allocate the sweeper at this level
        allocate(my_sweeper_t::pf%levels(l)%ulevel%sweeper)

--- a/Tutorials/EX2_Dahlquist/src/encap.f90
+++ b/Tutorials/EX2_Dahlquist/src/encap.f90
@@ -36,21 +36,23 @@ contains
   !>  The following are the base subroutines that encapsulation factories need to provide
   
   !>  Subroutine to allocate one encap
-  subroutine scalar_create_single(this, x, level, shape)
+  subroutine scalar_create_single(this, x, level_index, lev_shape)
     class(scalar_factory), intent(inout)              :: this
     class(pf_encap_t),      intent(inout), allocatable :: x
-    integer,                intent(in   )      :: level, shape(:)  ! passed by default, but not needed
+    integer,               intent(in   ) ::  level_index ! passed by default,  not needed here
+    integer,               intent(in   ) ::  lev_shape(:) ! passed by default, not needed here
     integer :: i
 
     allocate(scalar_encap::x)
   end subroutine scalar_create_single
 
   !> Subroutine to create an array of encaps
-  subroutine scalar_create_array(this, x, n, level,  shape)
+  subroutine scalar_create_array(this, x, n, level_index,lev_shape)
     class(scalar_factory), intent(inout)              :: this
-    class(pf_encap_t),      intent(inout), allocatable :: x(:)
-    integer,                intent(in   )              :: n  ! size of array to build
-    integer,                intent(in   )    ::  level, shape(:) ! passed by default, but not needed
+    class(pf_encap_t),     intent(inout), allocatable :: x(:)
+    integer,               intent(in   )              :: n  ! size of array to build
+    integer,               intent(in   ) ::  level_index ! passed by default,  not needed here
+    integer,               intent(in   ) ::  lev_shape(:) ! passed by default, not needed here
     integer :: i
     allocate(scalar_encap::x(n))
   end subroutine scalar_create_array

--- a/Tutorials/EX3_adv_diff/src/hooks.f90
+++ b/Tutorials/EX3_adv_diff/src/hooks.f90
@@ -14,7 +14,7 @@ contains
     type(pf_pfasst_t), intent(inout) :: pf
     integer, intent(in) :: level_index
 
-    real(pfdp) :: yexact(pf%levels(level_index)%shape(1))
+    real(pfdp) :: yexact(pf%levels(level_index)%lev_shape(1))
     real(pfdp), pointer :: y_end(:)
     real(pfdp) :: maxerr
     real(pfdp) :: residual

--- a/Tutorials/EX3_adv_diff/src/main.f90
+++ b/Tutorials/EX3_adv_diff/src/main.f90
@@ -36,8 +36,8 @@ contains
     !>  Local variables
     type(pf_pfasst_t) :: pf       !<  the main pfasst structure
     type(pf_comm_t)   :: comm     !<  the communicator (here it is mpi)
-    type(ndarray)     :: y_0      !<  the initial condition
-    type(ndarray)     :: y_end    !<  the solution at the final time
+    type(pf_ndarray_t):: y_0      !<  the initial condition
+    type(pf_ndarray_t):: y_end    !<  the solution at the final time
     character(256)    :: pf_fname   !<  file name for input of PFASST parameters
 
     integer           ::  l   !  loop variable over levels
@@ -57,7 +57,7 @@ contains
        allocate(ad_level_t::pf%levels(l)%ulevel)
 
        !>  Allocate the user specific data factory
-       allocate(ndarray_factory::pf%levels(l)%ulevel%factory)
+       allocate(pf_ndarray_factory_t::pf%levels(l)%ulevel%factory)
 
        !>  Add the sweeper to the level
        allocate(ad_sweeper_t::pf%levels(l)%ulevel%sweeper)

--- a/Tutorials/EX3_adv_diff/src/sweeper.f90
+++ b/Tutorials/EX3_adv_diff/src/sweeper.f90
@@ -72,7 +72,7 @@ contains
        this%explicit=.TRUE.
     end if
 
-    nx=pf%levels(level_index)%shape(1)  !  local convenient grid size
+    nx=pf%levels(level_index)%lev_shape(1)  !  local convenient grid size
 
     !>  Set up the FFT 
     allocate(this%fft_tool)

--- a/Tutorials/EX3_adv_diff/src/sweeper.f90
+++ b/Tutorials/EX3_adv_diff/src/sweeper.f90
@@ -214,7 +214,7 @@ contains
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   !> Routine to set initial condition.
   subroutine initial_sol(y_0)
-    type(ndarray), intent(inout) :: y_0
+    type(pf_ndarray_t), intent(inout) :: y_0
     call exact(0.0_pfdp, y_0%flatarray)
   end subroutine initial_sol
 

--- a/src/pf_amisdc_sweeper.f90
+++ b/src/pf_amisdc_sweeper.f90
@@ -29,49 +29,49 @@ module pf_mod_amisdc
   end type pf_amisdc_t
 
   interface 
-     subroutine pf_f1eval_p(this, y, t, level, f1)
+     subroutine pf_f1eval_p(this, y, t, level_index, f1)
        import pf_amisdc_t, pf_encap_t, pfdp
        class(pf_amisdc_t), intent(inout) :: this
        class(pf_encap_t),  intent(in   ) :: y
        class(pf_encap_t),  intent(inout) :: f1
        real(pfdp),         intent(in   ) :: t
-       integer,     intent(in   ) :: level
+       integer,     intent(in   ) :: level_index
      end subroutine pf_f1eval_p
 
-     subroutine pf_f2eval_p(this, y, t, level, f2)
+     subroutine pf_f2eval_p(this, y, t, level_index, f2)
        import pf_amisdc_t, pf_encap_t, pfdp
        class(pf_amisdc_t), intent(inout) :: this
        class(pf_encap_t),  intent(in   ) :: y
        class(pf_encap_t),  intent(inout) :: f2
        real(pfdp),         intent(in   ) :: t
-       integer,     intent(in   ) :: level
+       integer,     intent(in   ) :: level_index
      end subroutine pf_f2eval_p
 
-     subroutine pf_f2comp_p(this, y, t, dt, rhs, level, f2)
+     subroutine pf_f2comp_p(this, y, t, dt, rhs, level_index, f2)
        import pf_amisdc_t, pf_encap_t,  pfdp
        class(pf_amisdc_t), intent(inout) :: this
        class(pf_encap_t),  intent(in   ) :: rhs
        class(pf_encap_t),  intent(inout) :: y, f2
        real(pfdp),         intent(in   ) :: t, dt
-       integer,     intent(in   ) :: level
+       integer,     intent(in   ) :: level_index
      end subroutine pf_f2comp_p
 
-     subroutine pf_f3eval_p(this, y, t, level, f3)
+     subroutine pf_f3eval_p(this, y, t, level_index, f3)
        import pf_amisdc_t, pf_encap_t,  pfdp
        class(pf_amisdc_t), intent(inout) :: this
        class(pf_encap_t),  intent(in   ) :: y
        class(pf_encap_t),  intent(inout) :: f3
        real(pfdp),         intent(in   ) :: t
-       integer,     intent(in   ) :: level
+       integer,     intent(in   ) :: level_index
      end subroutine pf_f3eval_p
 
-     subroutine pf_f3comp_p(this, y, t, dt, rhs, level, f3)
+     subroutine pf_f3comp_p(this, y, t, dt, rhs, level_index, f3)
        import pf_amisdc_t, pf_encap_t,  pfdp
        class(pf_amisdc_t), intent(inout) :: this
        class(pf_encap_t), intent(in   ) :: rhs
        class(pf_encap_t), intent(inout) :: y, f3
        real(pfdp),        intent(in   ) :: t, dt
-       integer,    intent(in   ) :: level
+       integer,    intent(in   ) :: level_index
      end subroutine pf_f3comp_p
   end interface
 
@@ -112,10 +112,10 @@ contains
     call this%f2eval(lev%Q(1), t0, lev%index, lev%F(1,2))
     call this%f3eval(lev%Q(1), t0, lev%index, lev%F(1,3))
 
-    call lev%ulevel%factory%create_single(rhsA, lev%index, lev%shape)
-    call lev%ulevel%factory%create_single(rhsB, lev%index,  lev%shape)
-    call lev%ulevel%factory%create_single(QA,   lev%index,  lev%shape)
-    call lev%ulevel%factory%create_single(QB,   lev%index,  lev%shape)
+    call lev%ulevel%factory%create_single(rhsA, lev%index, lev%lev_shape)
+    call lev%ulevel%factory%create_single(rhsB, lev%index,  lev%lev_shape)
+    call lev%ulevel%factory%create_single(QA,   lev%index,  lev%lev_shape)
+    call lev%ulevel%factory%create_single(QB,   lev%index,  lev%lev_shape)
 
     call QA%setval(0.0_pfdp)
     call QB%setval(0.0_pfdp)
@@ -155,10 +155,10 @@ contains
     call lev%qend%copy(lev%Q(lev%nnodes))
 
     ! Destroy the temporary variables
-    call lev%ulevel%factory%destroy_single(rhsA, lev%index,  lev%shape)
-    call lev%ulevel%factory%destroy_single(rhsB, lev%index,  lev%shape)
-    call lev%ulevel%factory%destroy_single(QA,   lev%index,  lev%shape)
-    call lev%ulevel%factory%destroy_single(QB,   lev%index,  lev%shape)
+    call lev%ulevel%factory%destroy_single(rhsA, lev%index,  lev%lev_shape)
+    call lev%ulevel%factory%destroy_single(rhsB, lev%index,  lev%lev_shape)
+    call lev%ulevel%factory%destroy_single(QA,   lev%index,  lev%lev_shape)
+    call lev%ulevel%factory%destroy_single(QB,   lev%index,  lev%lev_shape)
 
     call end_timer(pf, TLEVEL+lev%index-1)
 

--- a/src/pf_amisdc_sweeperQ.f90
+++ b/src/pf_amisdc_sweeperQ.f90
@@ -44,8 +44,8 @@ contains
 
     call start_timer(pf, TLEVEL+lev%index-1)
    
-    call lev%ulevel%factory%create_array(S2,lev%nnodes-1,lev%index,lev%shape)
-    call lev%ulevel%factory%create_array(S3,lev%nnodes-1,lev%index,lev%shape)
+    call lev%ulevel%factory%create_array(S2,lev%nnodes-1,lev%index,lev%lev_shape)
+    call lev%ulevel%factory%create_array(S3,lev%nnodes-1,lev%index,lev%lev_shape)
     
     ! compute integrals and add fas correction
     do m = 1, lev%nnodes-1
@@ -73,10 +73,10 @@ contains
     call this%f2eval(lev%Q(1), t0, lev%index, lev%F(1,2))
     call this%f3eval(lev%Q(1), t0, lev%index, lev%F(1,3))
 
-    call lev%ulevel%factory%create_single(rhsA, lev%index,   lev%shape)
-    call lev%ulevel%factory%create_single(rhsB, lev%index,   lev%shape)
-    call lev%ulevel%factory%create_single(QA,   lev%index,   lev%shape)
-    call lev%ulevel%factory%create_single(QB,   lev%index,   lev%shape)
+    call lev%ulevel%factory%create_single(rhsA, lev%index,   lev%lev_shape)
+    call lev%ulevel%factory%create_single(rhsB, lev%index,   lev%lev_shape)
+    call lev%ulevel%factory%create_single(QA,   lev%index,   lev%lev_shape)
+    call lev%ulevel%factory%create_single(QB,   lev%index,   lev%lev_shape)
 
     call QA%setval(0.0_pfdp)
     call QB%setval(0.0_pfdp)
@@ -154,8 +154,8 @@ contains
 
     ! call start_timer(pf, TLEVEL+lev%index-1)
    
-    ! call lev%ulevel%factory%create_array(S2,lev%nnodes-1,lev%index,lev%shape)
-    ! call lev%ulevel%factory%create_array(S3,lev%nnodes-1,lev%index,lev%shape)
+    ! call lev%ulevel%factory%create_array(S2,lev%nnodes-1,lev%index,lev%lev_shape)
+    ! call lev%ulevel%factory%create_array(S3,lev%nnodes-1,lev%index,lev%lev_shape)
     
     ! ! compute integrals and add fas correction
     ! do m = 1, lev%nnodes-1
@@ -183,10 +183,10 @@ contains
     ! call this%f2eval(lev%Q(1), t0, lev%index, lev%F(1,2))
     ! call this%f3eval(lev%Q(1), t0, lev%index, lev%F(1,3))
 
-    ! call lev%ulevel%factory%create_single(rhsA, lev%index,  lev%shape)
-    ! call lev%ulevel%factory%create_single(rhsB, lev%index,  lev%shape)
-    ! call lev%ulevel%factory%create_single(QA,   lev%index,  lev%shape)
-    ! call lev%ulevel%factory%create_single(QB,   lev%index,  lev%shape)
+    ! call lev%ulevel%factory%create_single(rhsA, lev%index,  lev%lev_shape)
+    ! call lev%ulevel%factory%create_single(rhsB, lev%index,  lev%lev_shape)
+    ! call lev%ulevel%factory%create_single(QA,   lev%index,  lev%lev_shape)
+    ! call lev%ulevel%factory%create_single(QB,   lev%index,  lev%lev_shape)
 
     ! call QA%setval(0.0_pfdp)
     ! call QB%setval(0.0_pfdp)
@@ -233,12 +233,12 @@ contains
 
     ! call lev%qend%copy(lev%Q(lev%nnodes))
 
-    ! call lev%ulevel%factory%destroy_array(S2,lev%nnodes-1,lev%index,lev%shape)
-    ! call lev%ulevel%factory%destroy_array(S3,lev%nnodes-1,lev%index,lev%shape)
-    ! call lev%ulevel%factory%destroy_single(rhsA, lev%index,   lev%shape)
-    ! call lev%ulevel%factory%destroy_single(rhsB, lev%index,   lev%shape)
-    ! call lev%ulevel%factory%destroy_single(QA,   lev%index,   lev%shape)
-    ! call lev%ulevel%factory%destroy_single(QB,   lev%index,   lev%shape)
+    ! call lev%ulevel%factory%destroy_array(S2,lev%nnodes-1,lev%index,lev%lev_shape)
+    ! call lev%ulevel%factory%destroy_array(S3,lev%nnodes-1,lev%index,lev%lev_shape)
+    ! call lev%ulevel%factory%destroy_single(rhsA, lev%index,   lev%lev_shape)
+    ! call lev%ulevel%factory%destroy_single(rhsB, lev%index,   lev%lev_shape)
+    ! call lev%ulevel%factory%destroy_single(QA,   lev%index,   lev%lev_shape)
+    ! call lev%ulevel%factory%destroy_single(QB,   lev%index,   lev%lev_shape)
 
     ! call end_timer(pf, TLEVEL+lev%index-1)
         

--- a/src/pf_comm.f90
+++ b/src/pf_comm.f90
@@ -166,7 +166,7 @@ contains
 !     ierror = 0
     call start_timer(pf, TSEND + level%index - 1)
     if (pf%debug) print*,  'DEBUG --',pf%rank, 'begin send, tag=',tag,blocking,' pf%state%status =',pf%state%status
-!     if (pf%debug) print*,  'DEBUG --',pf%rank, size(level%send), 'send buffer=',level%send
+!     if (pf%debug) print*,  'DEBUG --',pf%rank, SIZE(level%send), 'send buffer=',level%send
 
     call pf%comm%send(pf, level, tag, blocking, ierror, dest)
     if (ierror /= 0) then
@@ -199,7 +199,7 @@ contains
                                   .and. dir == 1) then
        source=pf%rank-1
        call pf%comm%recv(pf, level,tag, blocking, ierror, source)
-!        if (pf%debug) print*,  'DEBUG --',pf%rank, size(level%recv), 'recv buffer=',level%recv
+!        if (pf%debug) print*,  'DEBUG --',pf%rank, SIZE(level%recv), 'recv buffer=',level%recv
 
 
        if (ierror .eq. 0) then
@@ -213,7 +213,7 @@ contains
                                      .and. dir == 2) then
        source=pf%rank+1
        call pf%comm%recv(pf, level,tag, blocking, ierror, source)
-!        if (pf%debug) print*,  'DEBUG --',pf%rank, size(level%recv), 'recv buffer=',level%recv
+!        if (pf%debug) print*,  'DEBUG --',pf%rank, SIZE(level%recv), 'recv buffer=',level%recv
 
 
        if (ierror .eq. 0) then
@@ -268,7 +268,7 @@ contains
        do m = 1, lev%nnodes
           call lev%pQ(m)%copy(lev%Q(m), flags)
           if (lev%Finterp) then
-             do p = 1,size(lev%F(1,:))
+             do p = 1,SIZE(lev%F(1,:))
                 call lev%pF(m,p)%copy(lev%F(m,p), flags)
              end do
           end if

--- a/src/pf_dtype.f90
+++ b/src/pf_dtype.f90
@@ -44,8 +44,8 @@ module pf_mod_dtype
     integer :: pfblock  !! pfasst block being worked on
     integer :: iter     !! current iteration number
     integer :: step     !! current time step number assigned to processor
-    integer :: level    !! which level is currently being operated on
-    integer :: finest_level    !! the current finest level (for variable depth V cycles)
+    integer :: level_index  !! which level is currently being operated on
+    integer :: finest_level !! the current finest level (for variable depth V cycles)
     integer :: hook     !! which hook
     integer :: proc     !! which processor
     integer :: sweep    !! sweep number
@@ -197,7 +197,7 @@ module pf_mod_dtype
           c_delta(:), &    ! delta on the coarse level
           f_encap_array_c(:)  !  fine solution restricted in space only
      
-     integer, allocatable :: shape(:)   !! user defined shape array
+     integer, allocatable :: lev_shape(:)   !! user defined shape array
      type(pf_sdcmats_t), allocatable :: sdcmats
      logical :: allocated = .false.
   end type pf_level_t
@@ -237,7 +237,7 @@ module pf_mod_dtype
      integer :: nblocks
      integer :: nsweeps
      integer :: rank
-     integer :: level
+     integer :: level_index
 
      character(len=128) :: datpath
      procedure(pf_results_p), pointer, nopass :: destroy 
@@ -447,18 +447,18 @@ module pf_mod_dtype
      end subroutine pf_transfer_p
 
      !> encapsulation interfaces
-     subroutine pf_encap_create_single_p(this, x, level, shape)
+     subroutine pf_encap_create_single_p(this, x, level_index, lev_shape)
        import pf_factory_t, pf_encap_t
        class(pf_factory_t), intent(inout)              :: this
        class(pf_encap_t),   intent(inout), allocatable :: x
-       integer,      intent(in   )              :: level,  shape(:)
+       integer,      intent(in   )              :: level_index,  lev_shape(:)
      end subroutine pf_encap_create_single_p
 
-     subroutine pf_encap_create_array_p(this, x, n, level, shape)
+     subroutine pf_encap_create_array_p(this, x, n, level_index, lev_shape)
        import pf_factory_t, pf_encap_t
        class(pf_factory_t), intent(inout)              :: this
        class(pf_encap_t),   intent(inout), allocatable :: x(:)
-       integer,      intent(in   )              :: n, level, shape(:)
+       integer,      intent(in   )              :: n, level_index, lev_shape(:)
      end subroutine pf_encap_create_array_p
 
      subroutine pf_encap_destroy_single_p(this, x)

--- a/src/pf_exp_sweeper.f90
+++ b/src/pf_exp_sweeper.f90
@@ -183,19 +183,19 @@ type, extends(pf_sweeper_t), abstract :: pf_exp_t
         !   t     (input) DOUBLE
         !         time t
         !
-        !   level (input) INTEGER
+        !   level_index (input) INTEGER
         !         current level index
         !
         !   f     (output) pf_encap_t
         !         N(t,y)
         ! =================================================================================
 
-        subroutine pf_f_eval_p(this, y, t, level, n)
+        subroutine pf_f_eval_p(this, y, t, level_index, n)
             import pf_exp_t, pf_encap_t, pfdp
             class(pf_exp_t),   intent(inout) :: this
             class(pf_encap_t), intent(in)    :: y
             real(pfdp),        intent(in)    :: t
-            integer,           intent(in)    :: level
+            integer,           intent(in)    :: level_index
             class(pf_encap_t), intent(inout) :: n
         end subroutine pf_f_eval_p
 
@@ -238,14 +238,14 @@ type, extends(pf_sweeper_t), abstract :: pf_exp_t
         allocate(this%w(nnodes - 1, nnodes, nnodes))
         do i = 1, nnodes - 1
             q = this%nodes - this%nodes(i);
-            call weights(this, real(0.0, pfdp), q, nnodes - 1, this%W(i,:,:))
+            call weights(this, REAL(0.0, pfdp), q, nnodes - 1, this%W(i,:,:))
         end do
         ! set number of rhs components
         this%npieces = 1
         ! initialize temporary storage objects
-        call lev%ulevel%factory%create_single(this%newF, lev%index, lev%shape)
-        call lev%ulevel%factory%create_array(this%b, nnodes + 1, lev%index, lev%shape)
-        call lev%ulevel%factory%create_array(this%f_old, nnodes, lev%index, lev%shape)
+        call lev%ulevel%factory%create_single(this%newF, lev%index, lev%lev_shape)
+        call lev%ulevel%factory%create_array(this%b, nnodes + 1, lev%index, lev%lev_shape)
+        call lev%ulevel%factory%create_array(this%f_old, nnodes, lev%index, lev%lev_shape)
 
     end subroutine exp_initialize
 
@@ -291,10 +291,10 @@ type, extends(pf_sweeper_t), abstract :: pf_exp_t
               call LocalDerivsAtNode(this, j, nnodes, this%f_old, this%b)  ! phi expansion for exponential picard integral              
               call this%b(1)%copy(lev%Q(j))  ! add term \phi_0(tL) y_n
 
-              call this%b(2)%axpy(real(-1.0, pfdp), this%f_old(j))         ! add -\phi_1(tL) F_j^{[k]}
+              call this%b(2)%axpy(REAL(-1.0, pfdp), this%f_old(j))         ! add -\phi_1(tL) F_j^{[k]}
               call this%f_eval(lev%Q(j), t, lev%index, lev%F(j,1))      ! compute F_j^{[k+1]}
 
-              call this%b(2)%axpy(real(1.0, pfdp), lev%F(j,1))          ! add \phi_1(tL) F_j^{[k+1]}
+              call this%b(2)%axpy(REAL(1.0, pfdp), lev%F(j,1))          ! add \phi_1(tL) F_j^{[k+1]}
 
 
               ! compute phi products
@@ -514,7 +514,7 @@ type, extends(pf_sweeper_t), abstract :: pf_exp_t
 
         ! form nonlinear derivative vectors b
         do j = 1, nnodes                                                ! loop over derivatives j = 1 ... n
-            call N_deriv(j+1)%setval(real(0.0, pfdp))
+            call N_deriv(j+1)%setval(REAL(0.0, pfdp))
             do k = 1, nnodes                                            ! look over nodes k = 1 ... n
                 call N_deriv(j+1)%axpy(this%w(i, k, j), N_eval(k))
             end do
@@ -565,7 +565,7 @@ type, extends(pf_sweeper_t), abstract :: pf_exp_t
            W  = 0.0_pfdp
            W(1,1) = 1.0_pfdp
            
-           n = size(x)
+           n = SIZE(x)
            do i=2,n
               mn = min(i,m+1)
               c2 = 1.0_pfdp
@@ -576,13 +576,13 @@ type, extends(pf_sweeper_t), abstract :: pf_exp_t
                  c2 = c2*c3;
                  if(j == i-1) then
                     do k=mn,2,-1
-                       W(i,k) = c1*(real(k-1,pfdp)*W(i-1,k-1) - c5*W(i-1,k))/c2;
+                       W(i,k) = c1*(REAL(k-1,pfdp)*W(i-1,k-1) - c5*W(i-1,k))/c2;
                     enddo
                     
                     W(i,1) = -c1*c5*W(i-1,1)/c2;
                  endif
                  do k=mn,2,-1
-                    W(j,k) = (c4*W(j,k) - real(k-1,pfdp)*W(j,k-1))/c3;
+                    W(j,k) = (c4*W(j,k) - REAL(k-1,pfdp)*W(j,k-1))/c3;
                  enddo
                  W(j,1) = c4*W(j,1)/c3;
               enddo

--- a/src/pf_fft.f90
+++ b/src/pf_fft.f90
@@ -123,7 +123,7 @@ contains
 
     this%wk_1d=ghat
     call this%fftb()
-    g=real(this%wk_1d,pfdp)
+    g=REAL(this%wk_1d,pfdp)
   end subroutine ifft_1d
 
   subroutine ifft_2d(this, ghat,g)
@@ -133,7 +133,7 @@ contains
 
     this%wk_2d=ghat
     call this%fftb()
-    g=real(this%wk_2d,pfdp)
+    g=REAL(this%wk_2d,pfdp)
   end subroutine ifft_2d
 
     subroutine ifft_3d(this, ghat,g)
@@ -143,7 +143,7 @@ contains
 
     this%wk_3d=ghat
     call this%fftb()
-    g=real(this%wk_3d)
+    g=REAL(this%wk_3d)
   end subroutine ifft_3d
 
   !++++++++++ Forward FFT complex to complex   ++++++++++++++++
@@ -220,7 +220,7 @@ contains
     call this%fftf()
     this%wk_1d = this%wk_1d * op
     call this%fftb()
-    c=real(this%wk_1d,pfdp)
+    c=REAL(this%wk_1d,pfdp)
   end subroutine conv_1d
 
   ! Convolve g with spectral op and return in c
@@ -234,7 +234,7 @@ contains
     call this%fftf()
     this%wk_2d = this%wk_2d * op
     call this%fftb()
-    c=real(this%wk_2d,pfdp)        
+    c=REAL(this%wk_2d,pfdp)        
   end subroutine conv_2d
   
   subroutine conv_3d(this, g,op,c)
@@ -247,7 +247,7 @@ contains
     call this%fftf()
     this%wk_3d = this%wk_3d * op
     call this%fftb()
-    c=real(this%wk_3d,pfdp)            
+    c=REAL(this%wk_3d,pfdp)            
   end subroutine conv_3d
 
   ! Convolution in real space 
@@ -462,8 +462,8 @@ contains
     class(pf_fft_abs_t), intent(inout) :: this
     real(pfdp),         pointer :: yvec_f(:), yvec_c(:)
     integer :: nx_f, nx_c,irat
-    nx_f = size(yvec_f)
-    nx_c = size(yvec_c)
+    nx_f = SIZE(yvec_f)
+    nx_c = SIZE(yvec_c)
     irat  = nx_f/nx_c
 
     yvec_c = yvec_f(::irat)
@@ -473,8 +473,8 @@ contains
     real(pfdp),         pointer :: yvec_f(:,:), yvec_c(:,:)
     integer :: nx_f(2), nx_c(2), irat, jrat
 
-    nx_f = shape(yvec_f)
-    nx_c = shape(yvec_c)
+    nx_f = SHAPE(yvec_f)
+    nx_c = SHAPE(yvec_c)
 
     irat  = nx_f(1)/nx_c(1)
     jrat  = nx_f(2)/nx_c(2)
@@ -487,8 +487,8 @@ contains
     integer :: nx_f(3), nx_c(3)
     integer :: irat, jrat,krat
 
-    nx_f = shape(yvec_f)
-    nx_c = shape(yvec_c)
+    nx_f = SHAPE(yvec_f)
+    nx_c = SHAPE(yvec_c)
 
     irat  = nx_f(1)/nx_c(1)
     jrat  = nx_f(2)/nx_c(2)
@@ -502,8 +502,8 @@ contains
     complex(pfdp),  pointer :: yhat_f(:), yhat_c(:)
     integer :: nx_f, nx_c
 
-    nx_f = size(yhat_f)
-    nx_c = size(yhat_c)
+    nx_f = SIZE(yhat_f)
+    nx_c = SIZE(yhat_c)
 
     yhat_c=0.0_pfdp
     yhat_c(1:nx_c/2) = yhat_f(1:nx_c/2)
@@ -515,8 +515,8 @@ contains
     complex(pfdp),         pointer :: yhat_f(:,:), yhat_c(:,:)
 
     integer :: nx_f(2), nx_c(2),nf1,nf2,nc1,nc2
-    nx_f = shape(yhat_f)
-    nx_c = shape(yhat_c)
+    nx_f = SHAPE(yhat_f)
+    nx_c = SHAPE(yhat_c)
     
     nf1=nx_f(1)-nx_c(1)/2+2
     nf2=nx_f(2)-nx_c(2)/2+2
@@ -540,8 +540,8 @@ contains
     
     yhat_c = 0.0_pfdp
     
-    nx_f = shape(yhat_f)
-    nx_c = shape(yhat_c)
+    nx_f = SHAPE(yhat_f)
+    nx_c = SHAPE(yhat_c)
     
     nf1=nx_f(1)-nx_c(1)/2+2
     nf2=nx_f(2)-nx_c(2)/2+2

--- a/src/pf_fft.f90
+++ b/src/pf_fft.f90
@@ -441,7 +441,7 @@ contains
       select case (dir)
       case (1)  
          do i = 1, nx
-            deriv(i,:,:) = (0.0_pfdp,1.0_pfdp)*this%kx(k)
+            deriv(i,:,:) = (0.0_pfdp,1.0_pfdp)*this%kx(i)
          end do
       case (2)
          do j = 1, ny

--- a/src/pf_fftpack.f90
+++ b/src/pf_fftpack.f90
@@ -43,10 +43,10 @@ contains
     this%ndim=ndim
     
     !  FFT Storage parameters
-    nx=grid_shape(1)
+    nx=grid_SHAPE(1)
     this%nx = nx
     this%lensavx = 4*nx + 15
-    this%normfact=real(nx,pfdp)
+    this%normfact=REAL(nx,pfdp)
     
     allocate(this%workhatx(nx))   !  complex transform
     allocate(this%wsavex(this%lensavx))
@@ -57,10 +57,10 @@ contains
     
     if (ndim > 1) then
        !  FFT Storage
-       ny=grid_shape(2)       
+       ny=grid_SHAPE(2)       
        this%ny = ny
        this%lensavy = 4*ny + 15
-       this%normfact=real(nx*ny,pfdp)
+       this%normfact=REAL(nx*ny,pfdp)
        allocate(this%workhaty(ny))   !  complex transform
        allocate(this%wsavey(this%lensavy))
        this%Ly = 1.0_pfdp
@@ -70,10 +70,10 @@ contains
        
        if (ndim > 2) then
           !  FFT Storage
-          nz=grid_shape(3)       
+          nz=grid_SHAPE(3)       
           this%nz = nz
           this%lensavz = 4*nz + 15
-          this%normfact=real(nx*ny*nz,pfdp)
+          this%normfact=REAL(nx*ny*nz,pfdp)
           allocate(this%workhatz(nz))   !  complex transform
           allocate(this%wsavez(this%lensavz))
           this%Lz = 1.0_pfdp
@@ -98,9 +98,9 @@ contains
     om=two_pi/this%Lx                
     do i = 1, nx
        if (i <= nx/2+1) then
-          this%kx(i) = om*real(i-1,pfdp)
+          this%kx(i) = om*REAL(i-1,pfdp)
        else
-          this%kx(i) = om*real(-nx + i - 1,pfdp)
+          this%kx(i) = om*REAL(-nx + i - 1,pfdp)
        end if
     end do
 
@@ -109,9 +109,9 @@ contains
        om=two_pi/this%Ly 
        do j = 1, ny
           if (j <= ny/2+1) then
-             this%ky(j) = om*real(j-1,pfdp)
+             this%ky(j) = om*REAL(j-1,pfdp)
           else
-             this%ky(j) = om*real(-ny + j - 1,pfdp)
+             this%ky(j) = om*REAL(-ny + j - 1,pfdp)
           end if
        end do
     end if
@@ -121,9 +121,9 @@ contains
        om=two_pi / this%Lz 
        do k = 1,nz
           if (k <= nz/2+1) then
-             this%kz(k) = om*real(k-1,pfdp)
+             this%kz(k) = om*REAL(k-1,pfdp)
           else
-             this%kz(k) = om*real(-nz + k - 1,pfdp)
+             this%kz(k) = om*REAL(-nz + k - 1,pfdp)
           end if
        end do
     end if
@@ -281,7 +281,7 @@ contains
     call this%zinterp_1d(wk_c, wk_f)
     call fft_f%fftb()     !  internal inverse fft call
 
-    yvec_f=real(wk_f,pfdp) !  grab the real part
+    yvec_f=REAL(wk_f,pfdp) !  grab the real part
     
   end subroutine interp_1d
   subroutine interp_2d(this, yvec_c, fft_f,yvec_f)
@@ -301,7 +301,7 @@ contains
     call this%zinterp_2d(wk_c, wk_f)
     call fft_f%fftb()     !  internal inverse fft call
 
-    yvec_f=real(wk_f,pfdp)  !  grab the real part
+    yvec_f=REAL(wk_f,pfdp)  !  grab the real part
     
   end subroutine interp_2d
   subroutine interp_3d(this, yvec_c, fft_f,yvec_f)
@@ -320,7 +320,7 @@ contains
     call this%zinterp_3d(wk_c, wk_f)
     call fft_f%fftb()     !  internal inverse fft call
 
-    yvec_f=real(wk_f,pfdp)  !  grab the real part
+    yvec_f=REAL(wk_f,pfdp)  !  grab the real part
   end subroutine interp_3d
 
   !>  Interpolate from coarse  level to fine in spectral space
@@ -331,8 +331,8 @@ contains
 
     integer :: nx_f, nx_c
 
-    nx_f = size(yhat_f)
-    nx_c = size(yhat_c)
+    nx_f = SIZE(yhat_f)
+    nx_c = SIZE(yhat_c)
 
     yhat_f = 0.0_pfdp
     yhat_f(1:nx_c/2) = yhat_c(1:nx_c/2)
@@ -347,8 +347,8 @@ contains
 
     integer :: nx_f(2), nx_c(2),nf1,nf2,nc1,nc2
 
-    nx_f = shape(yhat_f)
-    nx_c = shape(yhat_c)
+    nx_f = SHAPE(yhat_f)
+    nx_c = SHAPE(yhat_c)
     
     nf1=nx_f(1)-nx_c(1)/2+2
     nf2=nx_f(2)-nx_c(2)/2+2
@@ -373,8 +373,8 @@ contains
     integer :: nx_f(3), nx_c(3),nf1,nf2,nf3,nc1,nc2,nc3
 
 
-    nx_f = shape(yhat_f)
-    nx_c = shape(yhat_c)
+    nx_f = SHAPE(yhat_f)
+    nx_c = SHAPE(yhat_c)
     
     nf1=nx_f(1)-nx_c(1)/2+2
     nf2=nx_f(2)-nx_c(2)/2+2

--- a/src/pf_fftw.f90
+++ b/src/pf_fftw.f90
@@ -45,7 +45,7 @@ contains
     type(c_ptr) :: wk
 
     this%ndim=ndim
-    nx=grid_shape(1)
+    nx=grid_SHAPE(1)
     this%nx = nx
 
     ! Defaults for grid_size
@@ -56,7 +56,7 @@ contains
     select case (ndim)
     case (1)            
        if(present(grid_size)) this%Lx = grid_size(1)
-       this%normfact=real(nx,pfdp)
+       this%normfact=REAL(nx,pfdp)
        wk = fftw_alloc_complex(int(nx, c_size_t))
        call c_f_pointer(wk, this%wk_1d, [nx])          
        
@@ -70,9 +70,9 @@ contains
           this%Ly = grid_size(2)
        end if
        
-       ny=grid_shape(2)          
+       ny=grid_SHAPE(2)          
        this%ny = ny
-       this%normfact=real(nx*ny,pfdp)
+       this%normfact=REAL(nx*ny,pfdp)
        ! create in-place, complex fft plans
        wk = fftw_alloc_complex(int(nx*ny, c_size_t))
        call c_f_pointer(wk, this%wk_2d, [nx,ny])
@@ -89,11 +89,11 @@ contains
           this%Lz = grid_size(3)
        end if
     
-       ny=grid_shape(2)          
-       nz=grid_shape(3)          
+       ny=grid_SHAPE(2)          
+       nz=grid_SHAPE(3)          
        this%ny = ny
        this%nz = nz
-       this%normfact=real(nx*ny*nz,pfdp)          
+       this%normfact=REAL(nx*ny*nz,pfdp)          
        wk = fftw_alloc_complex(int(nx*ny*nz, c_size_t))
        call c_f_pointer(wk, this%wk_3d, [nx,ny,nz])
        this%ffftw = fftw_plan_dft_3d(nx,ny,nz, &
@@ -109,9 +109,9 @@ contains
     om=two_pi/this%Lx                
     do i = 1, nx
        if (i <= nx/2+1) then
-          this%kx(i) = om*real(i-1,pfdp)
+          this%kx(i) = om*REAL(i-1,pfdp)
        else
-          this%kx(i) = om*real(-nx + i - 1,pfdp)
+          this%kx(i) = om*REAL(-nx + i - 1,pfdp)
        end if
     end do
 
@@ -120,9 +120,9 @@ contains
        om=two_pi/this%Ly 
        do j = 1, ny
           if (j <= ny/2+1) then
-             this%ky(j) = om*real(j-1,pfdp)
+             this%ky(j) = om*REAL(j-1,pfdp)
           else
-             this%ky(j) = om*real(-ny + j - 1,pfdp)
+             this%ky(j) = om*REAL(-ny + j - 1,pfdp)
           end if
        end do
     end if
@@ -132,9 +132,9 @@ contains
        om=two_pi / this%Lz 
        do k = 1,nz
           if (k <= nz/2+1) then
-             this%kz(k) = om*real(k-1,pfdp)
+             this%kz(k) = om*REAL(k-1,pfdp)
           else
-             this%kz(k) = om*real(-nz + k - 1,pfdp)
+             this%kz(k) = om*REAL(-nz + k - 1,pfdp)
           end if
        end do
     end if
@@ -220,7 +220,7 @@ contains
     call this%zinterp_1d(wk_c, wk_f)
     call fft_f%fftb()     !  internal inverse fft call
 
-    yvec_f=real(wk_f)     !  grab the real part
+    yvec_f=REAL(wk_f,pfdp)     !  grab the real part
     
   end subroutine interp_1d
   subroutine interp_2d(this, yvec_c, fft_f,yvec_f)
@@ -238,7 +238,7 @@ contains
     call this%fftf()                  !  internal forward fft call    
     call this%zinterp_2d(wk_c, wk_f)  !  interpolate in spectral space
     call fft_f%fftb()                 !  internal inverse fft call
-    yvec_f=real(wk_f)                 !  grab the real part
+    yvec_f=REAL(wk_f,pfdp)                 !  grab the real part
     
   end subroutine interp_2d
   subroutine interp_3d(this, yvec_c, fft_f,yvec_f)
@@ -256,7 +256,7 @@ contains
     call this%fftf()                 !  internal forward fft call    
     call this%zinterp_3d(wk_c, wk_f) ! interpolate in spectral space
     call fft_f%fftb()                ! internal inverse fft call
-    yvec_f=real(wk_f)                ! grab the real part
+    yvec_f=REAL(wk_f,pfdp)                ! grab the real part
 
   end subroutine interp_3d
 
@@ -267,8 +267,8 @@ contains
     complex(pfdp),   pointer,intent(in) :: yhat_c(:)
     integer :: nx_f, nx_c
     
-    nx_f = size(yhat_f)
-    nx_c = size(yhat_c)
+    nx_f = SIZE(yhat_f)
+    nx_c = SIZE(yhat_c)
     
     yhat_f = 0.0_pfdp
     yhat_f(1:nx_c/2) = yhat_c(1:nx_c/2)
@@ -282,8 +282,8 @@ contains
 
     integer :: nx_f(2), nx_c(2),nf1,nf2,nc1,nc2
 
-    nx_f = shape(yhat_f)
-    nx_c = shape(yhat_c)
+    nx_f = SHAPE(yhat_f)
+    nx_c = SHAPE(yhat_c)
     
     nf1=nx_f(1)-nx_c(1)/2+2
     nf2=nx_f(2)-nx_c(2)/2+2
@@ -304,16 +304,13 @@ contains
     complex(pfdp),   pointer,intent(inout) :: yhat_f(:,:,:) 
     complex(pfdp),   pointer,intent(in) :: yhat_c(:,:,:)
 
-  integer :: nx_f(3), nx_c(3),nf1,nf2,nf3,nc1,nc2,nc3
+    integer :: nx_f(3), nx_c(3),nf1,nf2,nf3,nc1,nc2,nc3
 
-
-    nx_f = size(yhat_f)
-    nx_c = size(yhat_c)
 
     yhat_f = 0.0_pfdp
   
-    nx_f = shape(yhat_f)
-    nx_c = shape(yhat_c)
+    nx_f = SHAPE(yhat_f)
+    nx_c = SHAPE(yhat_c)
     
     nf1=nx_f(1)-nx_c(1)/2+2
     nf2=nx_f(2)-nx_c(2)/2+2

--- a/src/pf_hooks.f90
+++ b/src/pf_hooks.f90
@@ -54,31 +54,31 @@ module pf_mod_hooks
 contains
 
   !> Subroutine to add a procedure to the hook on the given level
-  subroutine pf_add_hook(pf, level_ind, hook, proc)
+  subroutine pf_add_hook(pf, level_index, hook, proc)
     type(pf_pfasst_t), intent(inout) :: pf            !! main pfasst structure
-    integer,           intent(in)    :: level_ind     !! which pfasst level to add hook
+    integer,           intent(in)    :: level_index     !! which pfasst level to add hook
     integer,           intent(in)    :: hook          !! which hook to add
     procedure(pf_hook_p)             :: proc          !! precudre to call from hook
 
     integer :: l   !
 
-    if (level_ind == -1) then  ! Do to all levels
+    if (level_index == -1) then  ! Do to all levels
        do l = 1, pf%nlevels
           pf%nhooks(l,hook) = pf%nhooks(l,hook) + 1
           pf%hooks(l,hook,pf%nhooks(l,hook))%proc => proc
        end do
-    else  ! Do to just level level_ind
-       pf%nhooks(level_ind,hook) = pf%nhooks(level_ind,hook) + 1
-       pf%hooks(level_ind,hook,pf%nhooks(level_ind,hook))%proc => proc
+    else  ! Do to just level level_index
+       pf%nhooks(level_index,hook) = pf%nhooks(level_index,hook) + 1
+       pf%hooks(level_index,hook,pf%nhooks(level_index,hook))%proc => proc
     end if
 
   end subroutine pf_add_hook
 
   !> Subroutine to call hooks associated with the hook and level
-  subroutine call_hooks(pf, level_ind, hook)
+  subroutine call_hooks(pf, level_index, hook)
     use pf_mod_timer
     type(pf_pfasst_t), intent(inout), target :: pf         !! main pfasst structure
-    integer,           intent(in)            :: level_ind  !! which pfasst level to call hook
+    integer,           intent(in)            :: level_index  !! which pfasst level to call hook
     integer,           intent(in)            :: hook       !! which hook to call
 
     integer :: i  !!  hook loop index
@@ -87,15 +87,15 @@ contains
     call start_timer(pf, THOOKS)
 
     pf%state%hook = hook
-    if (level_ind == -1) then  ! Do to all levels
+    if (level_index == -1) then  ! Do to all levels
        do l = 1, pf%nlevels
           do i = 1, pf%nhooks(l,hook)
              call pf%hooks(l,hook,i)%proc(pf,l)
           end do
        end do
-    else  ! Do to just level level_ind
-       do i = 1, pf%nhooks(level_ind,hook)
-          call pf%hooks(level_ind,hook,i)%proc(pf,level_ind)
+    else  ! Do to just level level_index
+       do i = 1, pf%nhooks(level_index,hook)
+          call pf%hooks(level_index,hook,i)%proc(pf,level_index)
        end do
     end if
 

--- a/src/pf_imexQ_oc_sweeper.f90
+++ b/src/pf_imexQ_oc_sweeper.f90
@@ -257,10 +257,6 @@ contains
 ! !       call pf_residual(pf, lev, dt, which)
 !     end if
 
-
-    !  Make some space
-!     call Lev%encap%create(rhs, Lev%level, SDC_KIND_SOL_FEVAL, Lev%nvars, Lev%shape, Lev%ctx)
-
     if (sweep_y) then
       !  Forward sweep on y
       t = t0
@@ -480,7 +476,7 @@ contains
     this%QdiffI = lev%sdcmats%qmat-this%QtilI
 
     !!  Make space for rhs
-    call lev%ulevel%factory%create_single(this%rhs, lev%index, lev%shape)
+    call lev%ulevel%factory%create_single(this%rhs, lev%index, lev%lev_shape)
 
   end subroutine imexQ_oc_initialize
 

--- a/src/pf_imex_sweeper.f90
+++ b/src/pf_imex_sweeper.f90
@@ -184,6 +184,7 @@ contains
        end do  !!  End substep loop
        call pf_residual(pf, level_index, dt)
        call lev%qend%copy(lev%Q(lev%nnodes))
+
        call call_hooks(pf, level_index, PF_POST_SWEEP)
     end do  !  End loop on sweeps
 
@@ -245,7 +246,7 @@ contains
           this%QtilI(2:nnodes-1,:) = this%QtilI(2:nnodes-1,:)- this%QtilI(1:nnodes-2,:)
     end if
     !>  Make space for rhs
-    call lev%ulevel%factory%create_single(this%rhs, lev%index,   lev%shape)
+    call lev%ulevel%factory%create_single(this%rhs, lev%index,   lev%lev_shape)
 
   end subroutine imex_initialize
 

--- a/src/pf_imk_sweeper.f90
+++ b/src/pf_imk_sweeper.f90
@@ -343,7 +343,7 @@ contains
 
     !>  Make space for temporary variables
     call lev%ulevel%factory%create_array(this%A, nnodes, &
-         lev%index,   lev%shape)
+         lev%index,   lev%lev_shape)
 
     do m = 1, nnodes
        call this%A(m)%setval(0.0_pfdp)

--- a/src/pf_interpolate.f90
+++ b/src/pf_interpolate.f90
@@ -42,8 +42,8 @@ contains
 
     !> create workspaces
     if (f_lev_p%interp_workspace_allocated   .eqv. .false.) then  
-       call c_lev_p%ulevel%factory%create_array(f_lev_p%c_delta,  c_lev_p%nnodes, c_lev_p%index,  c_lev_p%shape)
-       call f_lev_p%ulevel%factory%create_array(f_lev_p%cf_delta, c_lev_p%nnodes, f_lev_p%index,  f_lev_p%shape)
+       call c_lev_p%ulevel%factory%create_array(f_lev_p%c_delta,  c_lev_p%nnodes, c_lev_p%index,  c_lev_p%lev_shape)
+       call f_lev_p%ulevel%factory%create_array(f_lev_p%cf_delta, c_lev_p%nnodes, f_lev_p%index,  f_lev_p%lev_shape)
        f_lev_p%interp_workspace_allocated  = .true.     
     end if
     !> set time at coarse and fine nodes
@@ -70,7 +70,7 @@ contains
 
     !> either interpolate function values or recompute them
     if (F_INTERP) then         !  Interpolating F
-      do p = 1,size(c_lev_p%F(1,:))
+      do p = 1,SIZE(c_lev_p%F(1,:))
           do m = 1, c_lev_p%nnodes
              call f_lev_p%c_delta(m)%setval(0.0_pfdp, flags)
              call f_lev_p%cf_delta(m)%setval(0.0_pfdp, flags)

--- a/src/pf_magpicard_sweeper.f90
+++ b/src/pf_magpicard_sweeper.f90
@@ -159,10 +159,10 @@ contains
     call get_commutator_coefs(this%qtype, nnodes, this%dt, this%commutator_coefs)
 
     call lev%ulevel%factory%create_array(this%omega, nnodes-1, &
-         lev%index,  lev%shape)
+         lev%index,  lev%lev_shape)
 
     call lev%ulevel%factory%create_array(this%time_ev_op, nnodes-1, &
-         lev%index,  lev%shape)
+         lev%index,  lev%lev_shape)
 
     do m = 1, nnodes-1
         call this%omega(m)%setval(0.0_pfdp)

--- a/src/pf_magpicard_sweeper.f90
+++ b/src/pf_magpicard_sweeper.f90
@@ -33,12 +33,12 @@ module pf_mod_magnus_picard
   end type pf_magpicard_t
 
   interface
-     subroutine pf_f_eval_p(this, y, t, level, f)
+     subroutine pf_f_eval_p(this, y, t, level_index, f)
        import pf_magpicard_t, pf_encap_t, pfdp
        class(pf_magpicard_t),  intent(inout) :: this
        class(pf_encap_t), intent(inout) :: y
        real(pfdp),        intent(in   ) :: t
-       integer,           intent(in   ) :: level
+       integer,           intent(in   ) :: level_index
        class(pf_encap_t), intent(inout) :: f
      end subroutine pf_f_eval_p
      subroutine pf_compute_single_commutators_p(this, f)
@@ -54,13 +54,13 @@ module pf_mod_magnus_picard
        real(pfdp), intent(in) :: coefs(:,:), nodes(:), qmat(:,:), dt
        integer, intent(in) :: this_node
      end subroutine pf_compute_omega_p
-     subroutine pf_propagate_solution_p(this, sol_t0, sol_tn, omega, level)
+     subroutine pf_propagate_solution_p(this, sol_t0, sol_tn, omega, level_index)
        import pf_magpicard_t, pf_encap_t, pfdp
        class(pf_magpicard_t),  intent(inout) :: this
        class(pf_encap_t), intent(inout) :: sol_t0
        class(pf_encap_t), intent(inout) :: omega
        class(pf_encap_t), intent(inout) :: sol_tn
-       integer, intent(in) :: level
+       integer, intent(in) :: level_index
      end subroutine pf_propagate_solution_p
   end interface
 contains

--- a/src/pf_misdcQ_oc_sweeper.f90
+++ b/src/pf_misdcQ_oc_sweeper.f90
@@ -279,10 +279,10 @@ contains
     this%QdiffI = lev%sdcmats%qmat-this%QtilI
 
     !>  Make space for rhs
-    call lev%ulevel%factory%create_single(this%rhs, lev%index, lev%shape)
+    call lev%ulevel%factory%create_single(this%rhs, lev%index, lev%lev_shape)
 
     !>  Make space for extra integration piece
-    call lev%ulevel%factory%create_array(this%I3,lev%nnodes-1,lev%index,lev%shape)
+    call lev%ulevel%factory%create_array(this%I3,lev%nnodes-1,lev%index,lev%lev_shape)
 
   end subroutine misdcQ_oc_initialize
 

--- a/src/pf_misdcQ_sweeper.f90
+++ b/src/pf_misdcQ_sweeper.f90
@@ -189,10 +189,10 @@ contains
     this%QdiffI = lev%sdcmats%qmat-this%QtilI
 
     !>  Make space for rhs
-    call lev%ulevel%factory%create_single(this%rhs, lev%index,   lev%shape)
+    call lev%ulevel%factory%create_single(this%rhs, lev%index,   lev%lev_shape)
 
     !>  Make space for extra integration piece
-    call lev%ulevel%factory%create_array(this%I3,lev%nnodes-1,lev%index,lev%shape)
+    call lev%ulevel%factory%create_array(this%I3,lev%nnodes-1,lev%index,lev%lev_shape)
 
   end subroutine misdcQ_initialize
 

--- a/src/pf_misdc_sweeper.f90
+++ b/src/pf_misdc_sweeper.f90
@@ -86,7 +86,7 @@ contains
     call this%f_eval(lev%Q(1), t0, lev%index, lev%F(1,2),2)
     call this%f_eval(lev%Q(1), t0, lev%index, lev%F(1,3),3)
 
-    call lev%ulevel%factory%create_single(rhs, lev%index,   lev%shape)
+    call lev%ulevel%factory%create_single(rhs, lev%index,   lev%lev_shape)
 
     t = t0
     dtsdc = dt * (lev%nodes(2:lev%nnodes) - lev%nodes(1:lev%nnodes-1))
@@ -111,7 +111,7 @@ contains
     call lev%qend%copy(lev%Q(lev%nnodes))
 
     ! done
-    call lev%ulevel%factory%destroy_single(rhs, lev%index,  lev%shape)
+    call lev%ulevel%factory%destroy_single(rhs, lev%index,  lev%lev_shape)
 
     call end_timer(pf, TLEVEL+lev%index-1)
 

--- a/src/pf_ndarray_encap.f90
+++ b/src/pf_ndarray_encap.f90
@@ -25,18 +25,19 @@ module pf_mod_ndarray
   implicit none
 
   !>  Type to create and destroy N-dimenstional arrays
-  type, extends(pf_factory_t) :: ndarray_factory
+  type, extends(pf_factory_t) :: pf_ndarray_factory_t
    contains
      procedure :: create_single  => ndarray_create_single
      procedure :: create_array  => ndarray_create_array
      procedure :: destroy_single => ndarray_destroy_single
      procedure :: destroy_array => ndarray_destroy_array
-  end type ndarray_factory
+  end type pf_ndarray_factory_t
+  
 
   !>  N-dimensional array type,  extends the abstract encap type
-  type, extends(pf_encap_t) :: ndarray
+  type, extends(pf_encap_t) :: pf_ndarray_t
      integer             :: ndim
-     integer,    allocatable :: shape(:)
+     integer,    allocatable :: arr_shape(:)
      real(pfdp), allocatable :: flatarray(:)
    contains
      procedure :: setval => ndarray_setval
@@ -46,15 +47,15 @@ module pf_mod_ndarray
      procedure :: unpack => ndarray_unpack
      procedure :: axpy => ndarray_axpy
      procedure :: eprint => ndarray_eprint
-  end type ndarray
+  end type pf_ndarray_t
 
 contains
   function cast_as_ndarray(encap_polymorph) result(ndarray_obj)
     class(pf_encap_t), intent(in), target :: encap_polymorph
-    type(ndarray), pointer :: ndarray_obj
+    type(pf_ndarray_t), pointer :: ndarray_obj
     
     select type(encap_polymorph)
-    type is (ndarray)
+    type is (pf_ndarray_t)
        ndarray_obj => encap_polymorph
     end select
   end function cast_as_ndarray
@@ -65,34 +66,34 @@ contains
     integer,           intent(in   ) :: shape_in(:)
 
     select type (q)
-    class is (ndarray)
-       allocate(q%shape(SIZE(shape_in)))
+    class is (pf_ndarray_t)
+       allocate(q%arr_shape(SIZE(shape_in)))
        allocate(q%flatarray(product(shape_in)))
        q%ndim   = SIZE(shape_in)
-       q%shape = shape_in
+       q%arr_shape = shape_in
     end select
   end subroutine ndarray_build
 
   !> Subroutine to  create a single array
   subroutine ndarray_create_single(this, x, level_index, lev_shape)
-    class(ndarray_factory), intent(inout)              :: this
+    class(pf_ndarray_factory_t), intent(inout)              :: this
     class(pf_encap_t),      intent(inout), allocatable :: x
     integer,                intent(in   )              :: level_index
     integer,                intent(in   )              :: lev_shape(:)
     integer :: i
-    allocate(ndarray::x)
+    allocate(pf_ndarray_t::x)
     call ndarray_build(x, lev_shape)
   end subroutine ndarray_create_single
 
   !> Subroutine to create an array of arrays
   subroutine ndarray_create_array(this, x, n, level_index,  lev_shape)
-    class(ndarray_factory), intent(inout)              :: this
+    class(pf_ndarray_factory_t), intent(inout)              :: this
     class(pf_encap_t),      intent(inout), allocatable :: x(:)
     integer,                intent(in   )              :: n
     integer,                intent(in   )              :: level_index
     integer,                intent(in   )              :: lev_shape(:)
     integer :: i
-    allocate(ndarray::x(n))
+    allocate(pf_ndarray_t::x(n))
     do i = 1, n
        call ndarray_build(x(i), lev_shape)
     end do
@@ -101,11 +102,11 @@ contains
   !>  Subroutine to destroy array
   subroutine ndarray_destroy(encap)
     class(pf_encap_t), intent(inout) :: encap
-    type(ndarray), pointer :: ndarray_obj
+    type(pf_ndarray_t), pointer :: ndarray_obj
 
     ndarray_obj => cast_as_ndarray(encap)
 
-    deallocate(ndarray_obj%shape)
+    deallocate(ndarray_obj%arr_shape)
     deallocate(ndarray_obj%flatarray)
 
     nullify(ndarray_obj)
@@ -114,12 +115,12 @@ contains
 
   !> Subroutine to destroy an single array
   subroutine ndarray_destroy_single(this, x)
-    class(ndarray_factory), intent(inout)              :: this
+    class(pf_ndarray_factory_t), intent(inout)              :: this
     class(pf_encap_t),      intent(inout), allocatable :: x
 
     select type (x)
-    class is (ndarray)
-       deallocate(x%shape)
+    class is (pf_ndarray_t)
+       deallocate(x%arr_shape)
        deallocate(x%flatarray)
     end select
     deallocate(x)
@@ -128,14 +129,14 @@ contains
 
   !> Subroutine to destroy an array of arrays
   subroutine ndarray_destroy_array(this, x)
-    class(ndarray_factory), intent(inout)              :: this
+    class(pf_ndarray_factory_t), intent(inout)              :: this
     class(pf_encap_t),      intent(inout),allocatable :: x(:)
     integer                                            :: i
 
     select type(x)
-    class is (ndarray)
+    class is (pf_ndarray_t)
        do i = 1,SIZE(x)
-          deallocate(x(i)%shape)
+          deallocate(x(i)%arr_shape)
           deallocate(x(i)%flatarray)
        end do
     end select
@@ -148,7 +149,7 @@ contains
   
   !> Subroutine to set array to a scalare  value.
   subroutine ndarray_setval(this, val, flags)
-    class(ndarray), intent(inout)           :: this
+    class(pf_ndarray_t), intent(inout)           :: this
     real(pfdp),     intent(in   )           :: val
     integer,        intent(in   ), optional :: flags
     this%flatarray = val
@@ -156,11 +157,11 @@ contains
 
   !> Subroutine to copy an array
   subroutine ndarray_copy(this, src, flags)
-    class(ndarray),    intent(inout)           :: this
+    class(pf_ndarray_t),    intent(inout)           :: this
     class(pf_encap_t), intent(in   )           :: src
     integer,           intent(in   ), optional :: flags
     select type(src)
-    type is (ndarray)
+    type is (pf_ndarray_t)
        this%flatarray = src%flatarray
     class default
        call pf_stop(__FILE__,__LINE__,'Type error')
@@ -169,7 +170,7 @@ contains
 
   !> Subroutine to pack an array into a flat array for sending
   subroutine ndarray_pack(this, z, flags)
-    class(ndarray), intent(in   ) :: this
+    class(pf_ndarray_t), intent(in   ) :: this
     real(pfdp),     intent(  out) :: z(:)
     integer,     intent(in   ), optional :: flags
     z = this%flatarray
@@ -177,7 +178,7 @@ contains
 
   !> Subroutine to unpack a flatarray after receiving
   subroutine ndarray_unpack(this, z, flags)
-    class(ndarray), intent(inout) :: this
+    class(pf_ndarray_t), intent(inout) :: this
     real(pfdp),     intent(in   ) :: z(:)
     integer,     intent(in   ), optional :: flags
     this%flatarray = z
@@ -185,7 +186,7 @@ contains
 
   !> Subroutine to define the norm of the array (here the max norm)
   function ndarray_norm(this, flags) result (norm)
-    class(ndarray), intent(in   ) :: this
+    class(pf_ndarray_t), intent(in   ) :: this
     integer,     intent(in   ), optional :: flags
     real(pfdp) :: norm
     norm = maxval(abs(this%flatarray))
@@ -193,14 +194,14 @@ contains
 
   !> Subroutine to compute y = a x + y where a is a scalar and x and y are arrays
   subroutine ndarray_axpy(this, a, x, flags)
-    class(ndarray),    intent(inout)           :: this
+    class(pf_ndarray_t),    intent(inout)           :: this
     class(pf_encap_t), intent(in   )           :: x
     real(pfdp),        intent(in   )           :: a
     integer,           intent(in   ), optional :: flags
 
 
     select type(x)
-    type is (ndarray)
+    type is (pf_ndarray_t)
        this%flatarray = a * x%flatarray + this%flatarray
     class default
        call pf_stop(__FILE__,__LINE__,'Type error')
@@ -209,10 +210,10 @@ contains
 
   !>  Subroutine to print the array to the screen (mainly for debugging purposes)
   subroutine ndarray_eprint(this,flags)
-    class(ndarray), intent(inout) :: this
+    class(pf_ndarray_t), intent(inout) :: this
     integer,           intent(in   ), optional :: flags
     !  Just print the first few values
-    if (product(this%shape) < 10) then
+    if (product(this%arr_shape) < 10) then
        print *, this%flatarray
     else
        print *, this%flatarray(1:10)
@@ -227,7 +228,7 @@ contains
     integer,           intent(in   ), optional :: flags
     real(pfdp), pointer :: r(:)
     select type (x)
-    type is (ndarray)
+    type is (pf_ndarray_t)
        r => x%flatarray
     end select
   end function get_array1d
@@ -239,8 +240,8 @@ contains
     real(pfdp), pointer :: r(:,:)
 
     select type (x)
-    type is (ndarray)
-       r(1:x%shape(1),1:x%shape(2)) => x%flatarray
+    type is (pf_ndarray_t)
+       r(1:x%arr_shape(1),1:x%arr_shape(2)) => x%flatarray
     end select
   end function get_array2d
   
@@ -251,8 +252,8 @@ contains
     real(pfdp), pointer :: r(:,:,:)
 
     select type (x)
-    type is (ndarray)
-       r(1:x%shape(1),1:x%shape(2),1:x%shape(3)) => x%flatarray
+    type is (pf_ndarray_t)
+       r(1:x%arr_shape(1),1:x%arr_shape(2),1:x%arr_shape(3)) => x%flatarray
     end select
   end function get_array3d
   

--- a/src/pf_parallel.f90
+++ b/src/pf_parallel.f90
@@ -148,7 +148,7 @@ contains
     if (pf%q0_style < 2) then  !  Spread q0 to all the nodes
        call f_lev%ulevel%sweeper%spreadq0(pf,pf%state%finest_level, t0)
     endif
-    if (pf%nlevels==1) return
+!    if (pf%nlevels==1) return
     !!
     !!  Step 2:   Proceed fine to coarse levels coarsening the fine solution and computing tau correction
     if (pf%debug) print*,  'DEBUG --', pf%rank, 'do coarsen  in predictor'

--- a/src/pf_parareal.f90
+++ b/src/pf_parareal.f90
@@ -40,11 +40,11 @@ contains
     !!  pass in the time step size and length of run
     if (present(nsteps)) then
       nsteps_loc = nsteps
-      tend_loc=dble(nsteps_loc*dt)
+      tend_loc=real(nsteps_loc*dt,pfdp)
     else
       nsteps_loc = ceiling(tend/dt)
       !  Do  sanity check on steps
-      if (abs(real(nsteps_loc,pfdp)-tend/dt) > dt/100.0) then
+      if (abs(real(nsteps_loc,pfdp)-tend/dt) > dt/1d-7) then
         print *,'dt=',dt
         print *,'nsteps=',nsteps_loc
         print *,'tend=',tend

--- a/src/pf_parareal.f90
+++ b/src/pf_parareal.f90
@@ -1,4 +1,4 @@
-!!  Routines that run the pararealalgorithm
+!!  Routines that run the parareal algorithm
 !
 ! This file is part of LIBPFASST.
 !
@@ -82,7 +82,7 @@ contains
     class(pf_encap_t), intent(inout), optional :: qend
     integer,           intent(in   ), optional :: flags(:)
 
-    class(pf_level_t), pointer :: lev_p  !!  pointer to the one level we are operating on
+    class(pf_level_t), pointer :: lev  !!  pointer to the one level we are operating on
     integer                   :: j, k
     integer                   :: nblocks !!  The number of blocks of steps to do
     integer                   :: nproc   !!  The number of processors being used
@@ -101,10 +101,10 @@ contains
     pf%state%finest_level = pf%nlevels
 
     !  pointer to finest  level to start
-    lev_p => pf%levels(pf%state%finest_level)
+    lev => pf%levels(pf%state%finest_level)
 
     !  Stick the initial condition into q0 (will happen on all processors)
-    call lev_p%q0%copy(q0, flags=0)
+    call lev%q0%copy(q0, flags=0)
 
 
     nproc = pf%comm%nproc
@@ -138,11 +138,11 @@ contains
 
        if (k > 1) then
           if (nproc > 1)  then
-             call lev_p%qend%pack(lev_p%send)    !!  Pack away your last solution
-             call pf_broadcast(pf, lev_p%send, lev_p%mpibuflen, pf%comm%nproc-1)
-             call lev_p%q0%unpack(lev_p%send)    !!  Everyone resets their q0
+             call lev%qend%pack(lev%send)    !!  Pack away your last solution
+             call pf_broadcast(pf, lev%send, lev%mpibuflen, pf%comm%nproc-1)
+             call lev%q0%unpack(lev%send)    !!  Everyone resets their q0
           else
-             call lev_p%q0%copy(lev_p%qend, flags=0)    !!  Just stick qend in q0
+             call lev%q0%copy(lev%qend, flags=0)    !!  Just stick qend in q0
           end if
 
           !>  Update the step and t0 variables for new block
@@ -181,7 +181,7 @@ contains
 
     !  Grab the last solution for return (if wanted)
     if (present(qend)) then
-       call qend%copy(lev_p%qend, flags=0)
+       call qend%copy(lev%qend, flags=0)
     end if
   end subroutine pf_parareal_block_run
   !>  The parareal predictor does a serial integration on the coarse level followed
@@ -193,8 +193,8 @@ contains
     real(pfdp),        intent(in   )         :: dt     !! time step
     integer,           intent(in   ), optional :: flags(:)  !!  User defined flags
 
-    class(pf_level_t), pointer :: c_lev_p
-    class(pf_level_t), pointer :: f_lev_p     !!
+    class(pf_level_t), pointer :: c_lev
+    class(pf_level_t), pointer :: f_lev     !!
     integer                   :: k,n               !!  Loop indices
     integer                   :: nsteps_c,nsteps_f    !!  Number of RK  steps
     integer                   :: level_index     !!  Local variable for looping over levels
@@ -205,29 +205,29 @@ contains
     call start_timer(pf, TPREDICTOR)
 
     !  This is for one two levels only or one if only RK is done
-    c_lev_p => pf%levels(1)
-    f_lev_p => pf%levels(pf%state%finest_level)
+    c_lev => pf%levels(1)
+    f_lev => pf%levels(pf%state%finest_level)
 
     if (pf%debug) print*, 'DEBUG --', pf%rank, 'beginning parareal predictor'
 
     !! Step 1. Getting the initial condition on the coarsest level
     if (pf%state%finest_level > 1) then
        if (pf%q0_style < 2) then  !  Copy coarse
-          call c_lev_p%q0%copy(f_lev_p%q0)
+          call c_lev%q0%copy(f_lev%q0)
        end if
     end if
     level_index = 1
 
     !!
     !! Step 2. Do coarse level integration, no communication necessary
-    nsteps_c= c_lev_p%ulevel%stepper%nsteps  !  Each processor integrates alone
+    nsteps_c= c_lev%ulevel%stepper%nsteps  !  Each processor integrates alone
     do n=1,pf%rank+1
-       if (n .gt. 1) call c_lev_p%q0%copy(c_lev_p%qend)       
+       if (n .gt. 1) call c_lev%q0%copy(c_lev%qend)       
        t0k      = dt*real(n-1,pfdp)
-       call c_lev_p%ulevel%stepper%do_n_steps(pf, 1, t0k, c_lev_p%q0,c_lev_p%qend,dt, nsteps_c)
+       call c_lev%ulevel%stepper%do_n_steps(pf, 1, t0k, c_lev%q0,c_lev%qend,dt, nsteps_c)
     end do
     ! Save the coarse level value
-    call c_lev_p%Q(2)%copy(c_lev_p%qend, flags=0)     
+    call c_lev%Q(2)%copy(c_lev%qend, flags=0)     
 
     call end_timer(pf, TPREDICTOR)
 
@@ -250,47 +250,47 @@ contains
     integer,           intent(in)    :: level_index_f  !! Finest level of V-cycle (not supported)
     integer, optional, intent(in)    :: flags
 
-    type(pf_level_t), pointer :: f_lev_p, c_lev_p
+    type(pf_level_t), pointer :: f_lev, c_lev
     integer :: level_index, j,nsteps_f,nsteps_c
 
     if (pf%nlevels <2) return     !  This is for two levels only
 
-    c_lev_p => pf%levels(1)
-    f_lev_p => pf%levels(2)
-    nsteps_c= c_lev_p%ulevel%stepper%nsteps
-    nsteps_f= f_lev_p%ulevel%stepper%nsteps  
+    c_lev => pf%levels(1)
+    f_lev => pf%levels(2)
+    nsteps_c= c_lev%ulevel%stepper%nsteps
+    nsteps_f= f_lev%ulevel%stepper%nsteps  
 
 
     !  Do fine steps with old initial condition
     if (pf%rank /= 0) then
-       call f_lev_p%q0%copy(c_lev_p%q0, flags=0)       !  Get fine initial condition
+       call f_lev%q0%copy(c_lev%q0, flags=0)       !  Get fine initial condition
     end if
-    call f_lev_p%ulevel%stepper%do_n_steps(pf, 2,pf%state%t0, f_lev_p%q0,f_lev_p%qend, dt, nsteps_f)
+    call f_lev%ulevel%stepper%do_n_steps(pf, 2,pf%state%t0, f_lev%q0,f_lev%qend, dt, nsteps_f)
     
     ! Get a new initial condition on coarse
-    call pf_recv(pf, c_lev_p, 10000+iteration, .true.)
+    call pf_recv(pf, c_lev, 10000+iteration, .true.)
 
     !  Step on coarse
-    call c_lev_p%ulevel%stepper%do_n_steps(pf, 1,pf%state%t0, c_lev_p%q0,c_lev_p%qend, dt, nsteps_c)
+    call c_lev%ulevel%stepper%do_n_steps(pf, 1,pf%state%t0, c_lev%q0,c_lev%qend, dt, nsteps_c)
 
     !  Compute the correction (store in Q(1))
-    call c_lev_p%Q(1)%copy(f_lev_p%qend, flags=0)  !  Current 
-    call c_lev_p%Q(1)%axpy(-1.0_pfdp,c_lev_p%Q(2)) !       
+    call c_lev%Q(1)%copy(f_lev%qend, flags=0)  !  Current 
+    call c_lev%Q(1)%axpy(-1.0_pfdp,c_lev%Q(2)) !       
 
     ! Save the result of the coarse sweep
-    call c_lev_p%Q(2)%copy(c_lev_p%qend, flags=0)     
+    call c_lev%Q(2)%copy(c_lev%qend, flags=0)     
 
     ! correct coarse level solution at end (the parareal correction)
-    call c_lev_p%qend%axpy(1.0_pfdp,c_lev_p%Q(1))    
+    call c_lev%qend%axpy(1.0_pfdp,c_lev%Q(1))    
 
     !  Send coarse forward  (nonblocking)
-    call pf_send(pf, c_lev_p, 10000+iteration, .false.)
+    call pf_send(pf, c_lev, 10000+iteration, .false.)
     
     !  Compute the jump in the initial condition
-    call f_lev_p%q0_delta%copy(c_lev_p%q0, flags=0)
-    call f_lev_p%q0_delta%axpy(-1.0d0,f_lev_p%q0, flags=0)
-    f_lev_p%residual=f_lev_p%q0_delta%norm(flags=0)
-    call pf_set_resid(pf,2,f_lev_p%residual)
+    call f_lev%q0_delta%copy(c_lev%q0, flags=0)
+    call f_lev%q0_delta%axpy(-1.0d0,f_lev%q0, flags=0)
+    f_lev%residual=f_lev%q0_delta%norm(flags=0)
+    call pf_set_resid(pf,2,f_lev%residual)
 
   end subroutine pf_parareal_v_cycle
   

--- a/src/pf_pfasst.f90
+++ b/src/pf_pfasst.f90
@@ -96,8 +96,8 @@ contains
     integer ::  buflen_local
 
     ! Allocate and set shape array for the level
-    allocate(pf%levels(level_index)%shape(size(shape_in)))
-    pf%levels(level_index)%shape = shape_in
+    allocate(pf%levels(level_index)%lev_shape(SIZE(shape_in)))
+    pf%levels(level_index)%lev_shape = shape_in
 
     !  Set the size of mpi buffer
     buflen_local= product(shape_in)
@@ -180,7 +180,7 @@ contains
 
     !> (re)allocate tauQ 
     if ((lev%index < pf%nlevels) .and. (.not. allocated(lev%tauQ))) then
-       call lev%ulevel%factory%create_array(lev%tauQ, nnodes-1, lev%index,  lev%shape)
+       call lev%ulevel%factory%create_array(lev%tauQ, nnodes-1, lev%index,  lev%lev_shape)
     end if
 
     !> skip the rest if we're already allocated
@@ -217,25 +217,25 @@ contains
     !> allocate solution and function arrays
     npieces = lev%ulevel%sweeper%npieces
 
-    call lev%ulevel%factory%create_array(lev%Q, nnodes, lev%index,  lev%shape)
-    call lev%ulevel%factory%create_array(lev%Fflt, nnodes*npieces, lev%index,  lev%shape)
+    call lev%ulevel%factory%create_array(lev%Q, nnodes, lev%index,  lev%lev_shape)
+    call lev%ulevel%factory%create_array(lev%Fflt, nnodes*npieces, lev%index,  lev%lev_shape)
     do i = 1, nnodes*npieces
        call lev%Fflt(i)%setval(0.0_pfdp, 0)
     end do
 
     lev%F(1:nnodes,1:npieces) => lev%Fflt
-    call lev%ulevel%factory%create_array(lev%I, nnodes-1, lev%index,  lev%shape)
-    call lev%ulevel%factory%create_array(lev%R, nnodes-1, lev%index,  lev%shape)
+    call lev%ulevel%factory%create_array(lev%I, nnodes-1, lev%index,  lev%lev_shape)
+    call lev%ulevel%factory%create_array(lev%R, nnodes-1, lev%index,  lev%lev_shape)
 
     !  Need space for old function values in im sweepers
-    call lev%ulevel%factory%create_array(lev%pFflt, nnodes*npieces, lev%index, lev%shape)
+    call lev%ulevel%factory%create_array(lev%pFflt, nnodes*npieces, lev%index, lev%lev_shape)
     lev%pF(1:nnodes,1:npieces) => lev%pFflt
     if (lev%index < pf%nlevels) then
-       call lev%ulevel%factory%create_array(lev%pQ, nnodes, lev%index,  lev%shape)
+       call lev%ulevel%factory%create_array(lev%pQ, nnodes, lev%index,  lev%lev_shape)
     end if
-    call lev%ulevel%factory%create_single(lev%qend, lev%index,   lev%shape)
-    call lev%ulevel%factory%create_single(lev%q0, lev%index,   lev%shape)
-    call lev%ulevel%factory%create_single(lev%q0_delta, lev%index,   lev%shape)
+    call lev%ulevel%factory%create_single(lev%qend, lev%index,   lev%lev_shape)
+    call lev%ulevel%factory%create_single(lev%q0, lev%index,   lev%lev_shape)
+    call lev%ulevel%factory%create_single(lev%q0_delta, lev%index,   lev%lev_shape)
     
   end subroutine pf_level_setup
 
@@ -311,8 +311,8 @@ contains
     call lev%ulevel%sweeper%destroy(pf,level_index)
 
     !> deallocate misc. arrays
-    if (allocated(lev%shape)) then
-       deallocate(lev%shape)
+    if (allocated(lev%lev_shape)) then
+       deallocate(lev%lev_shape)
     end if
 
     if (allocated(lev%tmat)) then

--- a/src/pf_quadrature.f90
+++ b/src/pf_quadrature.f90
@@ -605,7 +605,7 @@ contains
     real(pfqp), intent(inout) :: a(:)
     integer :: iq
 
-    if (size(a) > 1) then
+    if (SIZE(a) > 1) then
        call qsort_partition(a, iq)
        call qsort(a(:iq-1))
        call qsort(a(iq:))
@@ -621,7 +621,7 @@ contains
 
     x = a(1)
     i = 0
-    j = size(a) + 1
+    j = SIZE(a) + 1
 
     do
        j = j-1

--- a/src/pf_restrict.f90
+++ b/src/pf_restrict.f90
@@ -127,7 +127,7 @@ contains
     !!  Create a temp array for the spatial restriction
     if (f_lev_p%restrict_workspace_allocated   .eqv. .false.) then      
        print *,'create in restrict'
-       call c_lev_p%ulevel%factory%create_array(f_lev_p%f_encap_array_c, f_nnodes, c_lev_p%index, c_lev_p%shape)
+       call c_lev_p%ulevel%factory%create_array(f_lev_p%f_encap_array_c, f_nnodes, c_lev_p%index, c_lev_p%lev_shape)
        f_lev_p%restrict_workspace_allocated  = .true.
     end if
  
@@ -171,7 +171,7 @@ contains
     !!  Create a temp array for the spatial restriction
     if (f_lev_p%restrict_workspace_allocated   .eqv. .false.) then      
        print *,'create in restrict'
-       call c_lev_p%ulevel%factory%create_array(f_lev_p%f_encap_array_c, f_nnodes, c_lev_p%index, c_lev_p%shape)
+       call c_lev_p%ulevel%factory%create_array(f_lev_p%f_encap_array_c, f_nnodes, c_lev_p%index, c_lev_p%lev_shape)
        f_lev_p%restrict_workspace_allocated  = .true.
     end if
 

--- a/src/pf_restrict.f90
+++ b/src/pf_restrict.f90
@@ -27,8 +27,8 @@ contains
     integer, optional, intent(in)    :: flags, mystep    
 
     !>  Local variables
-    class(pf_level_t), pointer :: c_lev_p    
-    class(pf_level_t), pointer :: f_lev_p
+    class(pf_level_t), pointer :: c_lev    
+    class(pf_level_t), pointer :: f_lev
 
     integer    :: m, step
 
@@ -36,8 +36,8 @@ contains
     real(pfdp), allocatable :: f_times(:)  !!  Simulation time at fine nodes
     
     
-    f_lev_p => pf%levels(level_index);
-    c_lev_p => pf%levels(level_index-1)
+    f_lev => pf%levels(level_index);
+    c_lev => pf%levels(level_index-1)
     
     step = pf%state%step+1
     if(present(mystep)) step = mystep
@@ -46,51 +46,51 @@ contains
     call start_timer(pf, TRESTRICT + level_index - 1)
     
 
-    allocate(c_times(c_lev_p%nnodes))
-    allocate(f_times(f_lev_p%nnodes))
+    allocate(c_times(c_lev%nnodes))
+    allocate(f_times(f_lev%nnodes))
 
     !> restrict q's and recompute f's
-    c_times = t0 + dt*c_lev_p%nodes
-    f_times = t0 + dt*f_lev_p%nodes
+    c_times = t0 + dt*c_lev%nodes
+    f_times = t0 + dt*f_lev%nodes
 
-    call restrict_ts(f_lev_p, c_lev_p, f_lev_p%Q, c_lev_p%Q, f_times, flags)
+    call restrict_ts(f_lev, c_lev, f_lev%Q, c_lev%Q, f_times, flags)
 
     !>  Recompute the functions
-    call c_lev_p%ulevel%sweeper%evaluate_all(pf,level_index-1, c_times, flags=flags, step=step)
+    call c_lev%ulevel%sweeper%evaluate_all(pf,level_index-1, c_times, flags=flags, step=step)
 
     !>  Compute  FAS correction
-    do m = 1, c_lev_p%nnodes-1
-       call c_lev_p%tauQ(m)%setval(0.0_pfdp, flags)
+    do m = 1, c_lev%nnodes-1
+       call c_lev%tauQ(m)%setval(0.0_pfdp, flags)
     end do
     if (pf%state%iter >= pf%taui0)  then
        ! compute '0 to node' integral on the coarse level
-      call c_lev_p%ulevel%sweeper%integrate(pf,level_index-1,  c_lev_p%Q, &
-           c_lev_p%F, dt, c_lev_p%I, flags)
+      call c_lev%ulevel%sweeper%integrate(pf,level_index-1,  c_lev%Q, &
+           c_lev%F, dt, c_lev%I, flags)
        ! compute '0 to node' integral on the fine level
-      call f_lev_p%ulevel%sweeper%integrate(pf,level_index, f_lev_p%Q, &
-        f_lev_p%F, dt, f_lev_p%I, flags)
+      call f_lev%ulevel%sweeper%integrate(pf,level_index, f_lev%Q, &
+        f_lev%F, dt, f_lev%I, flags)
        !  put tau in on fine level
       if (level_index < pf%state%finest_level) then
-          do m = 1, f_lev_p%nnodes-1
-             call f_lev_p%I(m)%axpy(1.0_pfdp, f_lev_p%tauQ(m), flags)
+          do m = 1, f_lev%nnodes-1
+             call f_lev%I(m)%axpy(1.0_pfdp, f_lev%tauQ(m), flags)
           end do
        end if
        !  Subtract coarse integral
-       do m = 1, c_lev_p%nnodes-1
-          call c_lev_p%tauQ(m)%axpy(-1.0_pfdp, c_lev_p%I(m), flags)
+       do m = 1, c_lev%nnodes-1
+          call c_lev%tauQ(m)%axpy(-1.0_pfdp, c_lev%I(m), flags)
        end do
 
        ! restrict '0 to node' integral on the fine level  in time and space
-       call restrict_ts_integral(f_lev_p, c_lev_p, f_lev_p%I, c_lev_p%I, f_times, flags)
+       call restrict_ts_integral(f_lev, c_lev, f_lev%I, c_lev%I, f_times, flags)
 
        ! Add fine restriction of fine integral (stored on coarse)
-       do m = 1, c_lev_p%nnodes-1
-          call c_lev_p%tauQ(m)%axpy(1.0_pfdp, c_lev_p%I(m), flags)
+       do m = 1, c_lev%nnodes-1
+          call c_lev%tauQ(m)%axpy(1.0_pfdp, c_lev%I(m), flags)
        end do
 
 !!$       if (pf%use_Sform) then
-!!$          do m = c_lev_p%nnodes-1,2,-1
-!!$!             call c_lev_p%tauQ(m)%axpy(-1.0_pfdp, c_lev_p%tauQ(m-1), flags)
+!!$          do m = c_lev%nnodes-1,2,-1
+!!$!             call c_lev%tauQ(m)%axpy(-1.0_pfdp, c_lev%tauQ(m-1), flags)
 !!$          end do
 !!$       end if
        
@@ -105,13 +105,13 @@ contains
   end subroutine restrict_time_space_fas
 
 
-  subroutine restrict_ts(f_lev_p, c_lev_p, f_encap_array, c_encap_array, f_time, flags)
+  subroutine restrict_ts(f_lev, c_lev, f_encap_array, c_encap_array, f_time, flags)
 
     !! Restrict (in time and space) f_sol_array  to c_sol_array
     !! This version is for point values (either functions or solutions)
     
-    class(pf_level_t),  intent(inout) :: f_lev_p   !!   pointer to fine level
-    class(pf_level_t),  intent(inout) :: c_lev_p   !!   pointer to coarse level
+    class(pf_level_t),  intent(inout) :: f_lev   !!   pointer to fine level
+    class(pf_level_t),  intent(inout) :: c_lev   !!   pointer to coarse level
     class(pf_encap_t),  intent(inout) :: f_encap_array(:)   !! array of fine level data to be restricted
     class(pf_encap_t),  intent(inout) :: c_encap_array(:)   !! array of coarse level data to be computed
     real(pfdp),         intent(in) :: f_time(:)             !! time at the fine nodes
@@ -121,40 +121,40 @@ contains
     integer :: f_nnodes,c_nnodes
 
 
-    f_nnodes = f_lev_p%nnodes
-    c_nnodes = c_lev_p%nnodes
+    f_nnodes = f_lev%nnodes
+    c_nnodes = c_lev%nnodes
 
     !!  Create a temp array for the spatial restriction
-    if (f_lev_p%restrict_workspace_allocated   .eqv. .false.) then      
+    if (f_lev%restrict_workspace_allocated   .eqv. .false.) then      
        print *,'create in restrict'
-       call c_lev_p%ulevel%factory%create_array(f_lev_p%f_encap_array_c, f_nnodes, c_lev_p%index, c_lev_p%lev_shape)
-       f_lev_p%restrict_workspace_allocated  = .true.
+       call c_lev%ulevel%factory%create_array(f_lev%f_encap_array_c, f_nnodes, c_lev%index, c_lev%lev_shape)
+       f_lev%restrict_workspace_allocated  = .true.
     end if
  
     !  spatial restriction
     do m = 1, f_nnodes
-       call f_lev_p%ulevel%restrict(f_lev_p, c_lev_p, f_encap_array(m), f_lev_p%f_encap_array_c(m), f_time(m), flags)
+       call f_lev%ulevel%restrict(f_lev, c_lev, f_encap_array(m), f_lev%f_encap_array_c(m), f_time(m), flags)
     end do
 
     ! temporal restriction
     if (present(flags)) then
        if ((flags .eq. 0) .or. (flags .eq. 1)) &
-            call pf_apply_mat(c_encap_array, 1.0_pfdp, f_lev_p%rmat, f_lev_p%f_encap_array_c, .true., flags)
+            call pf_apply_mat(c_encap_array, 1.0_pfdp, f_lev%rmat, f_lev%f_encap_array_c, .true., flags)
        if ((flags .eq. 0) .or. (flags .eq. 2)) &
-            call pf_apply_mat_backward(c_encap_array, 1.0_pfdp, f_lev_p%rmat, f_lev_p%f_encap_array_c, .true., flags=2)
+            call pf_apply_mat_backward(c_encap_array, 1.0_pfdp, f_lev%rmat, f_lev%f_encap_array_c, .true., flags=2)
     else
-       call pf_apply_mat(c_encap_array, 1.0_pfdp, f_lev_p%rmat, f_lev_p%f_encap_array_c, .true.)
+       call pf_apply_mat(c_encap_array, 1.0_pfdp, f_lev%rmat, f_lev%f_encap_array_c, .true.)
     end if
 
   end subroutine restrict_ts
 
-  subroutine restrict_ts_integral(f_lev_p, c_lev_p, f_encap_array, c_encap_array,f_time, flags)
+  subroutine restrict_ts_integral(f_lev, c_lev, f_encap_array, c_encap_array,f_time, flags)
 
     !! Restrict (in time and space) f_sol_array  to c_sol_array
     !! This version is for integrals
     
-    class(pf_level_t),  intent(inout) :: f_lev_p   !!   pointer to fine level
-    class(pf_level_t),  intent(inout) :: c_lev_p   !!   pointer to coarse level
+    class(pf_level_t),  intent(inout) :: f_lev   !!   pointer to fine level
+    class(pf_level_t),  intent(inout) :: c_lev   !!   pointer to coarse level
     class(pf_encap_t),  intent(inout) :: f_encap_array(:)   !! array of fine level data to be restricted
     class(pf_encap_t),  intent(inout) :: c_encap_array(:)   !! array of coarse level data to be computed
     real(pfdp),         intent(in) :: f_time(:)             !! time at the fine nodes
@@ -165,30 +165,30 @@ contains
     integer :: f_nnodes,c_nnodes
 
 
-    f_nnodes = f_lev_p%nnodes
-    c_nnodes = c_lev_p%nnodes
+    f_nnodes = f_lev%nnodes
+    c_nnodes = c_lev%nnodes
 
     !!  Create a temp array for the spatial restriction
-    if (f_lev_p%restrict_workspace_allocated   .eqv. .false.) then      
+    if (f_lev%restrict_workspace_allocated   .eqv. .false.) then      
        print *,'create in restrict'
-       call c_lev_p%ulevel%factory%create_array(f_lev_p%f_encap_array_c, f_nnodes, c_lev_p%index, c_lev_p%lev_shape)
-       f_lev_p%restrict_workspace_allocated  = .true.
+       call c_lev%ulevel%factory%create_array(f_lev%f_encap_array_c, f_nnodes, c_lev%index, c_lev%lev_shape)
+       f_lev%restrict_workspace_allocated  = .true.
     end if
 
     !  spatial restriction
     do m = 1, f_nnodes-1
-       call f_lev_p%ulevel%restrict(f_lev_p, c_lev_p, f_encap_array(m), f_lev_p%f_encap_array_c(m), f_time(m), flags)
+       call f_lev%ulevel%restrict(f_lev, c_lev, f_encap_array(m), f_lev%f_encap_array_c(m), f_time(m), flags)
     end do
     
     ! temporal restriction
     ! when restricting '0 to node' integral terms, skip the first entry since it is zero
     if (present(flags)) then
        if ((flags .eq. 0) .or. (flags .eq. 1)) &
-            call pf_apply_mat(c_encap_array, 1.0_pfdp, f_lev_p%rmat(2:,2:), f_lev_p%f_encap_array_c, .true., flags=1)
+            call pf_apply_mat(c_encap_array, 1.0_pfdp, f_lev%rmat(2:,2:), f_lev%f_encap_array_c, .true., flags=1)
        if ((flags .eq. 0) .or. (flags .eq. 2)) &
-            call pf_apply_mat_backward(c_encap_array, 1.0_pfdp, f_lev_p%rmat(2:,2:), f_lev_p%f_encap_array_c, .true., flags=2)
+            call pf_apply_mat_backward(c_encap_array, 1.0_pfdp, f_lev%rmat(2:,2:), f_lev%f_encap_array_c, .true., flags=2)
     else
-       call pf_apply_mat(c_encap_array, 1.0_pfdp, f_lev_p%rmat(2:,2:), f_lev_p%f_encap_array_c, .true.)
+       call pf_apply_mat(c_encap_array, 1.0_pfdp, f_lev%rmat(2:,2:), f_lev%f_encap_array_c, .true.)
     end if
 
   end subroutine restrict_ts_integral

--- a/src/pf_results.f90
+++ b/src/pf_results.f90
@@ -50,7 +50,7 @@ contains
     this%nprocs=nprocs_in
     this%nsweeps=nsweeps_in
     this%rank=rank_in
-    this%level=level_index    
+    this%level_index=level_index    
     
     if(.not.allocated(this%errors)) allocate(this%errors(niters_in, this%nblocks, nsweeps_in))
     if(.not.allocated(this%residuals)) allocate(this%residuals(niters_in, this%nblocks, nsweeps_in))
@@ -76,7 +76,7 @@ contains
     istat= system('mkdir -p ' // trim(datpath))
     if (istat .ne. 0) call pf_stop(__FILE__,__LINE__, "Cannot make directory in dump_resids")
 
-    write (fname, "(A5,I0.1,A4)") '/Lev_',this%level,'.dat'
+    write (fname, "(A5,I0.1,A4)") '/Lev_',this%level_index,'.dat'
     fullname = trim(datpath) // trim(fname)
     !  output residuals
     open(100+this%rank, file=trim(fullname), form='formatted')
@@ -105,7 +105,7 @@ contains
     
     if (istat .ne. 0) call pf_stop(__FILE__,__LINE__, "Cannot make directory in dump_errors")
 
-    write (fname, "(A6,I0.3,A5,I0.1,A4)") '/Proc_',this%rank,'_Lev_',this%level,'.dat'
+    write (fname, "(A6,I0.3,A5,I0.1,A4)") '/Proc_',this%rank,'_Lev_',this%level_index,'.dat'
     fullname = trim(datpath) // trim(fname)
     !  output errors
     open(100+this%rank, file=trim(fullname), form='formatted')

--- a/src/pf_rkstepper.f90
+++ b/src/pf_rkstepper.f90
@@ -298,11 +298,11 @@ contains
     end select
 
     ! Allocate space for local variables
-    call lev%ulevel%factory%create_single(this%rhs, level_index,  lev%shape)
-    call lev%ulevel%factory%create_single(this%q0, level_index,  lev%shape)
-    call lev%ulevel%factory%create_single(this%qend, level_index,  lev%shape)
-    call lev%ulevel%factory%create_single(this%qtemp, level_index,  lev%shape)            
-    call lev%ulevel%factory%create_array(lev%Frkflt, nstages*npieces, level_index,  lev%shape)
+    call lev%ulevel%factory%create_single(this%rhs, level_index,  lev%lev_shape)
+    call lev%ulevel%factory%create_single(this%q0, level_index,  lev%lev_shape)
+    call lev%ulevel%factory%create_single(this%qend, level_index,  lev%lev_shape)
+    call lev%ulevel%factory%create_single(this%qtemp, level_index,  lev%lev_shape)            
+    call lev%ulevel%factory%create_array(lev%Frkflt, nstages*npieces, level_index,  lev%lev_shape)
     do i = 1, nstages*npieces
        call lev%Frkflt(i)%setval(0.0_pfdp, 0)
     end do

--- a/src/pf_solutions.f90
+++ b/src/pf_solutions.f90
@@ -77,9 +77,9 @@ contains
     integer    :: nx, i
     real(pfdp) :: x
     
-    nx = size(uex)
+    nx = SIZE(uex)
     do i = 1, nx
-       x = Lx*real(i-1,pfdp)/real(nx,pfdp) 
+       x = Lx*REAL(i-1,pfdp)/REAL(nx,pfdp) 
        uex(i) = ad_cos_ex(t, x,nu,v,kfreq,Lx)
     end do
 
@@ -93,9 +93,9 @@ contains
     integer    :: nx, i
     real(pfdp) :: x
     
-    nx = size(uex)
+    nx = SIZE(uex)
     do i = 1, nx
-       x = Lx*real(i-1,pfdp)/real(nx,pfdp) 
+       x = Lx*REAL(i-1,pfdp)/REAL(nx,pfdp) 
        uex(i) = ad_cos_ex(t, x,nu,v,kfreq,Lx)       
     end do
 
@@ -109,14 +109,14 @@ contains
     integer    :: nx,ny, i,j
     real(pfdp) :: x, y,uy
     
-    nx = size(uex,1)
-    ny = size(uex,2)    
+    nx = SIZE(uex,1)
+    ny = SIZE(uex,2)    
 
     do j = 1, ny
-       y = Lx(2)*real(j-1,pfdp)/real(ny,pfdp)
+       y = Lx(2)*REAL(j-1,pfdp)/REAL(ny,pfdp)
        uy=ad_cos_ex(t, y,nu,v(2),kfreq(2),Lx(2))              
        do i = 1, nx
-          x = Lx(1)*real(i-1,pfdp)/real(nx,pfdp) 
+          x = Lx(1)*REAL(i-1,pfdp)/REAL(nx,pfdp) 
           uex(i,j) = ad_cos_ex(t, x,nu,v(1),kfreq(1),Lx(1))*uy
        end do
     end do
@@ -131,13 +131,13 @@ contains
     integer    :: nx,ny, i,j
     real(pfdp) :: x, y,uy
     
-    nx = size(uex,1)
-    ny = size(uex,2)    
+    nx = SIZE(uex,1)
+    ny = SIZE(uex,2)    
     do j = 1, ny
-       y = Lx(2)*real(j-1,pfdp)/real(ny,pfdp)
+       y = Lx(2)*REAL(j-1,pfdp)/REAL(ny,pfdp)
        uy=ad_cos_ex(t, y,nu,v(2),kfreq(2),Lx(2))              
        do i = 1, nx
-          x = Lx(1)*real(i-1,pfdp)/real(nx,pfdp) 
+          x = Lx(1)*REAL(i-1,pfdp)/REAL(nx,pfdp) 
           uex(i,j) = ad_cos_ex(t, x,nu,v(1),kfreq(1),Lx(1))*uy
        end do
     end do
@@ -151,18 +151,18 @@ contains
     integer    :: nx,ny,nz, i,j,k
     real(pfdp) :: x, y,z,uy,uz
     
-    nx = size(uex,1)
-    ny = size(uex,2)    
-    nz = size(uex,3)    
+    nx = SIZE(uex,1)
+    ny = SIZE(uex,2)    
+    nz = SIZE(uex,3)    
 
     do k = 1, nz
-       z = Lx(3)*real(k-1,pfdp)/real(nz,pfdp) 
+       z = Lx(3)*REAL(k-1,pfdp)/REAL(nz,pfdp) 
        uz=ad_cos_ex(t, z,nu,v(3),kfreq(3),Lx(3))              
        do j = 1, ny
-          y = Lx(2)*real(j-1,pfdp)/real(ny,pfdp)
+          y = Lx(2)*REAL(j-1,pfdp)/REAL(ny,pfdp)
           uy=ad_cos_ex(t, y,nu,v(2),kfreq(2),Lx(2))              
           do i = 1, nx
-             x = Lx(1)*real(i-1,pfdp)/real(nx,pfdp) 
+             x = Lx(1)*REAL(i-1,pfdp)/REAL(nx,pfdp) 
              uex(i,j,k) = ad_cos_ex(t, x,nu,v(1),kfreq(1),Lx(1))*uy*uz
           end do
        end do
@@ -178,18 +178,18 @@ contains
     integer    :: nx,ny,nz, i,j,k
     real(pfdp) :: x, y,z,uy,uz
     
-    nx = size(uex,1)
-    ny = size(uex,2)    
-    nz = size(uex,3)    
+    nx = SIZE(uex,1)
+    ny = SIZE(uex,2)    
+    nz = SIZE(uex,3)    
 
     do k = 1, nz
-       z = Lx(3)*real(k-1,pfdp)/real(nz,pfdp) 
+       z = Lx(3)*REAL(k-1,pfdp)/REAL(nz,pfdp) 
        uz=ad_cos_ex(t, z,nu,v(3),kfreq(3),Lx(3))              
        do j = 1, ny
-          y = Lx(2)*real(j-1,pfdp)/real(ny,pfdp)
+          y = Lx(2)*REAL(j-1,pfdp)/REAL(ny,pfdp)
           uy=ad_cos_ex(t, y,nu,v(2),kfreq(2),Lx(2))              
           do i = 1, nx
-             x = Lx(1)*real(i-1,pfdp)/real(nx,pfdp) 
+             x = Lx(1)*REAL(i-1,pfdp)/REAL(nx,pfdp) 
              uex(i,j,k) = ad_cos_ex(t, x,nu,v(1),kfreq(1),Lx(1))*uy*uz
           end do
        end do
@@ -214,13 +214,13 @@ contains
        t0=0.0025_pfdp/nu
        nbox = ceiling(sqrt(4.0_pfdp*nu*(t0+t)*37.0_pfdp))  !  Decide how many periodic images
        do k = -nbox,nbox
-          xx = x- 0.5_pfdp*Lx - t*v + real(k,pfdp)*Lx
+          xx = x- 0.5_pfdp*Lx - t*v + REAL(k,pfdp)*Lx
           u = u + sqrt(t0)/sqrt(t0+t)*exp(-xx*xx/(4.0_pfdp*nu*(t0+t)))
        end do
     else
        nbox = ceiling(sqrt(37.0d0))  !  Decide how many periodic images
        do k = -nbox,nbox
-          xx = x - 0.5_pfdp*Lx- t*v  + real(k,pfdp)*Lx
+          xx = x - 0.5_pfdp*Lx- t*v  + REAL(k,pfdp)*Lx
           u = u + exp(-xx*xx/(4.0_pfdp*0.0025_pfdp))
        end do
        
@@ -236,9 +236,9 @@ contains
     integer    :: nx, i
     real(pfdp) :: x
     
-    nx = size(uex)
+    nx = SIZE(uex)
     do i = 1, nx
-       x = Lx*real(i-1,pfdp)/real(nx,pfdp) 
+       x = Lx*REAL(i-1,pfdp)/REAL(nx,pfdp) 
        uex(i) = ad_exp_ex(t, x,nu,v,Lx)
     end do
 
@@ -252,9 +252,9 @@ contains
     integer    :: nx, i
     real(pfdp) :: x
     
-    nx = size(uex)
+    nx = SIZE(uex)
     do i = 1, nx
-       x = Lx*real(i-1,pfdp)/real(nx,pfdp) 
+       x = Lx*REAL(i-1,pfdp)/REAL(nx,pfdp) 
        uex(i) = ad_exp_ex(t, x,nu,v,Lx)       
     end do
 
@@ -268,14 +268,14 @@ contains
     integer    :: nx,ny, i,j
     real(pfdp) :: x, y,uy
     
-    nx = size(uex,1)
-    ny = size(uex,2)    
+    nx = SIZE(uex,1)
+    ny = SIZE(uex,2)    
 
     do j = 1, ny
-       y = Lx(2)*real(j-1,pfdp)/real(ny,pfdp)
+       y = Lx(2)*REAL(j-1,pfdp)/REAL(ny,pfdp)
        uy=ad_exp_ex(t, y,nu,v(2),Lx(2))              
        do i = 1, nx
-          x = Lx(1)*real(i-1,pfdp)/real(nx,pfdp) 
+          x = Lx(1)*REAL(i-1,pfdp)/REAL(nx,pfdp) 
           uex(i,j) = ad_exp_ex(t, x,nu,v(1),Lx(1))*uy
        end do
     end do
@@ -290,13 +290,13 @@ contains
     integer    :: nx,ny, i,j
     real(pfdp) :: x, y,uy
     
-    nx = size(uex,1)
-    ny = size(uex,2)    
+    nx = SIZE(uex,1)
+    ny = SIZE(uex,2)    
     do j = 1, ny
-       y = Lx(2)*real(j-1,pfdp)/real(ny,pfdp)
+       y = Lx(2)*REAL(j-1,pfdp)/REAL(ny,pfdp)
        uy=ad_exp_ex(t, y,nu,v(2),Lx(2))              
        do i = 1, nx
-          x = Lx(1)*real(i-1,pfdp)/real(nx,pfdp) 
+          x = Lx(1)*REAL(i-1,pfdp)/REAL(nx,pfdp) 
           uex(i,j) = ad_exp_ex(t, x,nu,v(1),Lx(1))*uy
        end do
     end do
@@ -310,18 +310,18 @@ contains
     integer    :: nx,ny,nz, i,j,k
     real(pfdp) :: x, y,z,uy,uz
     
-    nx = size(uex,1)
-    ny = size(uex,2)    
-    nz = size(uex,3)    
+    nx = SIZE(uex,1)
+    ny = SIZE(uex,2)    
+    nz = SIZE(uex,3)    
 
     do k = 1, nz
-       z = Lx(3)*real(k-1,pfdp)/real(nz,pfdp) 
+       z = Lx(3)*REAL(k-1,pfdp)/REAL(nz,pfdp) 
        uz=ad_exp_ex(t, z,nu,v(3),Lx(3))              
        do j = 1, ny
-          y = Lx(2)*real(j-1,pfdp)/real(ny,pfdp)
+          y = Lx(2)*REAL(j-1,pfdp)/REAL(ny,pfdp)
           uy=ad_exp_ex(t, y,nu,v(2),Lx(2))              
           do i = 1, nx
-             x = Lx(1)*real(i-1,pfdp)/real(nx,pfdp) 
+             x = Lx(1)*REAL(i-1,pfdp)/REAL(nx,pfdp) 
              uex(i,j,k) = ad_exp_ex(t, x,nu,v(1),Lx(1))*uy*uz
           end do
        end do
@@ -337,18 +337,18 @@ contains
     integer    :: nx,ny,nz, i,j,k
     real(pfdp) :: x, y,z,uy,uz
     
-    nx = size(uex,1)
-    ny = size(uex,2)    
-    nz = size(uex,3)    
+    nx = SIZE(uex,1)
+    ny = SIZE(uex,2)    
+    nz = SIZE(uex,3)    
 
     do k = 1, nz
-       z = Lx(3)*real(k-1,pfdp)/real(nz,pfdp) 
+       z = Lx(3)*REAL(k-1,pfdp)/REAL(nz,pfdp) 
        uz=ad_exp_ex(t, z,nu,v(3),Lx(3))              
        do j = 1, ny
-          y = Lx(2)*real(j-1,pfdp)/real(ny,pfdp)
+          y = Lx(2)*REAL(j-1,pfdp)/REAL(ny,pfdp)
           uy=ad_exp_ex(t, y,nu,v(2),Lx(2))              
           do i = 1, nx
-             x = Lx(1)*real(i-1,pfdp)/real(nx,pfdp) 
+             x = Lx(1)*REAL(i-1,pfdp)/REAL(nx,pfdp) 
              uex(i,j,k) = ad_exp_ex(t, x,nu,v(1),Lx(1))*uy*uz
           end do
        end do
@@ -375,7 +375,7 @@ contains
 
     if (t .gt. 0.0_pfdp) then
        do n =  nterms,1,-1
-          rn = real(n,pfdp)
+          rn = REAL(n,pfdp)
           u=u - 2.0_pfdp*bessel_jn(n,rn*ts)/(rn*ts)*sin(rn*xs)
        end do
     else
@@ -394,9 +394,9 @@ contains
     integer    :: nx, i
     real(pfdp) :: x
     
-    nx = size(uex)
+    nx = SIZE(uex)
     do i = 1, nx
-       x = Lx*real(i-1,pfdp)/real(nx,pfdp) 
+       x = Lx*REAL(i-1,pfdp)/REAL(nx,pfdp) 
        uex(i) = burg_sin_ex(t, x,nu,Lx)
     end do
 
@@ -411,9 +411,9 @@ contains
     integer    :: nx, i
     real(pfdp) :: x
     
-    nx = size(uex)
+    nx = SIZE(uex)
     do i = 1, nx
-       x = Lx*real(i-1,pfdp)/real(nx,pfdp) 
+       x = Lx*REAL(i-1,pfdp)/REAL(nx,pfdp) 
        uex(i) = burg_sin_ex(t, x,nu,Lx)       
     end do
 
@@ -428,13 +428,13 @@ contains
     integer    :: nx,ny, i,j
     real(pfdp) :: x, y,uy,L
     
-    nx = size(uex,1)
-    ny = size(uex,2)    
+    nx = SIZE(uex,1)
+    ny = SIZE(uex,2)    
     L=0.5_pfdp*(Lx(1)+Lx(2))
     do j = 1, ny
-       y = Lx(2)*real(j-1,pfdp)/real(ny,pfdp)
+       y = Lx(2)*REAL(j-1,pfdp)/REAL(ny,pfdp)
        do i = 1, nx
-          x = Lx(1)*real(i-1,pfdp)/real(nx,pfdp) 
+          x = Lx(1)*REAL(i-1,pfdp)/REAL(nx,pfdp) 
           uex(i,j) = burg_sin_ex(2.0_pfdp*t, x+y,nu,L)
        end do
     end do
@@ -450,13 +450,13 @@ contains
     integer    :: nx,ny, i,j
     real(pfdp) :: x, y,L
     
-    nx = size(uex,1)
-    ny = size(uex,2)
+    nx = SIZE(uex,1)
+    ny = SIZE(uex,2)
     L=0.5_pfdp*(Lx(1)+Lx(2))
     do j = 1, ny
-       y = Lx(2)*real(j-1,pfdp)/real(ny,pfdp)
+       y = Lx(2)*REAL(j-1,pfdp)/REAL(ny,pfdp)
        do i = 1, nx
-          x = Lx(1)*real(i-1,pfdp)/real(nx,pfdp) 
+          x = Lx(1)*REAL(i-1,pfdp)/REAL(nx,pfdp) 
           uex(i,j) = burg_sin_ex(2.0_pfdp*t,x+y,nu,L)
        end do
     end do
@@ -471,16 +471,16 @@ contains
     integer    :: nx,ny,nz, i,j,k
     real(pfdp) :: x, y,z,L
     
-    nx = size(uex,1)
-    ny = size(uex,2)    
-    nz = size(uex,3)    
+    nx = SIZE(uex,1)
+    ny = SIZE(uex,2)    
+    nz = SIZE(uex,3)    
     L=(Lx(1)+Lx(2)+Lx(3))/3.0_pfdp
     do k = 1, nz
-       z = Lx(3)*real(k-1,pfdp)/real(nz,pfdp) 
+       z = Lx(3)*REAL(k-1,pfdp)/REAL(nz,pfdp) 
        do j = 1, ny
-          y = Lx(2)*real(j-1,pfdp)/real(ny,pfdp)
+          y = Lx(2)*REAL(j-1,pfdp)/REAL(ny,pfdp)
           do i = 1, nx
-             x = Lx(1)*real(i-1,pfdp)/real(nx,pfdp) 
+             x = Lx(1)*REAL(i-1,pfdp)/REAL(nx,pfdp) 
              uex(i,j,k) = burg_sin_ex(3.0_pfdp*t, x+y+z,nu,L)
           end do
        end do
@@ -497,16 +497,16 @@ contains
     integer    :: nx,ny,nz, i,j,k
     real(pfdp) :: x, y,z,L
     
-    nx = size(uex,1)
-    ny = size(uex,2)    
-    nz = size(uex,3)    
+    nx = SIZE(uex,1)
+    ny = SIZE(uex,2)    
+    nz = SIZE(uex,3)    
     L=(Lx(1)+Lx(2)+Lx(3))/3.0_pfdp
     do k = 1, nz
-       z = Lx(3)*real(k-1,pfdp)/real(nz,pfdp) 
+       z = Lx(3)*real(k-1,pfdp)/REAL(nz,pfdp) 
        do j = 1, ny
-          y = Lx(2)*real(j-1,pfdp)/real(ny,pfdp)
+          y = Lx(2)*REAL(j-1,pfdp)/REAL(ny,pfdp)
           do i = 1, nx
-             x = Lx(1)*real(i-1,pfdp)/real(nx,pfdp) 
+             x = Lx(1)*REAL(i-1,pfdp)/REAL(nx,pfdp) 
              uex(i,j,k) = burg_sin_ex(3.0_pfdp*t,x+y+z,nu,L)
           end do
        end do
@@ -546,9 +546,9 @@ contains
     integer    :: nx, i
     real(pfdp) :: x
     
-    nx = size(uex)
+    nx = SIZE(uex)
     do i = 1, nx
-       x = Lx*real(i-1,pfdp)/real(nx,pfdp) 
+       x = Lx*REAL(i-1,pfdp)/REAL(nx,pfdp) 
        uex(i) = nls_ex(t, x,Lx)       
     end do
 
@@ -562,13 +562,13 @@ contains
     integer    :: nx,ny, i,j
     real(pfdp) :: x, y,L
     
-    nx = size(uex,1)
-    ny = size(uex,2)
+    nx = SIZE(uex,1)
+    ny = SIZE(uex,2)
     L=0.5_pfdp*(Lx(1)+Lx(2))
     do j = 1, ny
-       y = Lx(2)*real(j-1,pfdp)/real(ny,pfdp)
+       y = Lx(2)*REAL(j-1,pfdp)/REAL(ny,pfdp)
        do i = 1, nx
-          x = Lx(1)*real(i-1,pfdp)/real(nx,pfdp) 
+          x = Lx(1)*REAL(i-1,pfdp)/REAL(nx,pfdp) 
           uex(i,j) = nls_ex(2.0_pfdp*t,x+y,L)
        end do
     end do
@@ -583,16 +583,16 @@ contains
     integer    :: nx,ny,nz, i,j,k
     real(pfdp) :: x, y,z,L
     
-    nx = size(uex,1)
-    ny = size(uex,2)    
-    nz = size(uex,3)    
+    nx = SIZE(uex,1)
+    ny = SIZE(uex,2)    
+    nz = SIZE(uex,3)    
     L=(Lx(1)+Lx(2)+Lx(3))/3.0_pfdp
     do k = 1, nz
-       z = Lx(3)*real(k-1,pfdp)/real(nz,pfdp) 
+       z = Lx(3)*real(k-1,pfdp)/REAL(nz,pfdp) 
        do j = 1, ny
-          y = Lx(2)*real(j-1,pfdp)/real(ny,pfdp)
+          y = Lx(2)*REAL(j-1,pfdp)/REAL(ny,pfdp)
           do i = 1, nx
-             x = Lx(1)*real(i-1,pfdp)/real(nx,pfdp) 
+             x = Lx(1)*REAL(i-1,pfdp)/REAL(nx,pfdp) 
              uex(i,j,k) = nls_ex(3.0_pfdp*t,x+y+z,L)
           end do
        end do
@@ -625,9 +625,9 @@ contains
     integer    :: nx, i
     real(pfdp) :: x
     
-    nx = size(uex)
+    nx = SIZE(uex)
     do i = 1, nx
-       x = Lx*real(i-1,pfdp)/real(nx,pfdp) 
+       x = Lx*REAL(i-1,pfdp)/REAL(nx,pfdp) 
        uex(i) = kdv_ex(t, x,beta,Lx)       
     end do
 
@@ -641,9 +641,9 @@ contains
     integer    :: nx, i
     real(pfdp) :: x
     
-    nx = size(uex)
+    nx = SIZE(uex)
     do i = 1, nx
-       x = Lx*real(i-1,pfdp)/real(nx,pfdp) 
+       x = Lx*REAL(i-1,pfdp)/REAL(nx,pfdp) 
        uex(i) = kdv_ex(t, x,beta,Lx)       
     end do
 
@@ -658,13 +658,13 @@ contains
     integer    :: nx,ny, i,j
     real(pfdp) :: x, y,L
     
-    nx = size(uex,1)
-    ny = size(uex,2)
+    nx = SIZE(uex,1)
+    ny = SIZE(uex,2)
     L=0.5_pfdp*(Lx(1)+Lx(2))
     do j = 1, ny
-       y = Lx(2)*real(j-1,pfdp)/real(ny,pfdp)
+       y = Lx(2)*REAL(j-1,pfdp)/REAL(ny,pfdp)
        do i = 1, nx
-          x = Lx(1)*real(i-1,pfdp)/real(nx,pfdp) 
+          x = Lx(1)*REAL(i-1,pfdp)/REAL(nx,pfdp) 
           uex(i,j) = kdv_ex(2.0_pfdp*t,x,beta,L)
        end do
     end do
@@ -680,16 +680,16 @@ contains
     integer    :: nx,ny,nz, i,j,k
     real(pfdp) :: x, y,z,L
     
-    nx = size(uex,1)
-    ny = size(uex,2)    
-    nz = size(uex,3)    
+    nx = SIZE(uex,1)
+    ny = SIZE(uex,2)    
+    nz = SIZE(uex,3)    
     L=(Lx(1)+Lx(2)+Lx(3))/3.0_pfdp
     do k = 1, nz
-       z = Lx(3)*real(k-1,pfdp)/real(nz,pfdp) 
+       z = Lx(3)*REAL(k-1,pfdp)/REAL(nz,pfdp) 
        do j = 1, ny
-          y = Lx(2)*real(j-1,pfdp)/real(ny,pfdp)
+          y = Lx(2)*REAL(j-1,pfdp)/REAL(ny,pfdp)
           do i = 1, nx
-             x = Lx(1)*real(i-1,pfdp)/real(nx,pfdp) 
+             x = Lx(1)*REAL(i-1,pfdp)/REAL(nx,pfdp) 
              uex(i,j,k) = kdv_ex(3.0_pfdp*t,x,beta,L)
           end do
        end do

--- a/src/pf_timer.f90
+++ b/src/pf_timer.f90
@@ -114,7 +114,7 @@ contains
        write(*, '("timer:",a16,", rank: ",i3,", step: ",i4, ", level: ", i3,' &
             // '", iter: ",i3, f23.8,f23.8,f23.8)') &
             timer_names(timer), pf%rank, &
-            pf%state%step, pf%state%level, pf%state%iter,  &
+            pf%state%step, pf%state%level_index, pf%state%iter,  &
             t-pf%timers(timer), pf%runtimes(timer), t-pf%timers(TTOTAL)
     end if
 

--- a/src/pf_utils.f90
+++ b/src/pf_utils.f90
@@ -238,8 +238,8 @@ contains
     lzero = .true.; if (present(zero_first)) lzero = zero_first
     which = 1;      if(present(flags)) which = flags
         
-    n = size(mat, dim=1)
-    m = size(mat, dim=2)
+    n = SIZE(mat, dim=1)
+    m = SIZE(mat, dim=2)
         
     do i = 1, n
       if (lzero) call dst(i)%setval(0.0_pfdp, flags)
@@ -272,8 +272,8 @@ contains
     if( which /= 2 ) &
       stop "pf_apply_mat_backward can only be used for restricting the backward integrals with which==2"
 
-    n = size(mat, dim=1)
-    m = size(mat, dim=2)
+    n = SIZE(mat, dim=1)
+    m = SIZE(mat, dim=2)
         
     do i = 1, n
       if (lzero) call dst(n+1-i)%setval(0.0_pfdp, 2)

--- a/src/pf_verlet_sweeper.f90
+++ b/src/pf_verlet_sweeper.f90
@@ -314,12 +314,11 @@ contains
     select case (this%whichQQ)
     case (0)  !  Collocation (make it the product)
        print *,'Making QQ by collocation Q*Q'
-       print *,size(this%Qmat)
+       print *,SIZE(this%Qmat)
        qtemp=0.0_pfdp
        qtemp(2:nnodes,:)=lev%sdcmats%qmat
        qtemp=matmul(qtemp,qtemp)
        this%QQmat = qtemp(2:nnodes,:)
-       print *,shape(this%QQmat)
     case (1)  !  Make the pair like in Lobatto A/B pair
        print *,'Making QQ by collocation Lobatto pair'
        qtemp=0.0_pfdp
@@ -383,7 +382,7 @@ contains
     deallocate(qtemp2)
 
     !>  Make space for rhs
-    call lev%ulevel%factory%create_single(this%rhs, lev%index,   lev%shape)
+    call lev%ulevel%factory%create_single(this%rhs, lev%index,   lev%lev_shape)
     
   end subroutine verlet_initialize
   

--- a/src/pf_zndarray_encap.f90
+++ b/src/pf_zndarray_encap.f90
@@ -25,18 +25,18 @@ module pf_mod_zndarray
   implicit none
 
   !>  Factory for making zndarray
-  type, extends(pf_factory_t) :: zndarray_factory
+  type, extends(pf_factory_t) :: pf_zndarray_factory_t
   contains
      procedure :: create_single => zndarray_create_single
      procedure :: create_array => zndarray_create_array
      procedure :: destroy_single => zndarray_destroy_single
      procedure :: destroy_array => zndarray_destroy_array
-  end type zndarray_factory
-
+  end type pf_zndarray_factory_t
+  
   !>  Complex ndarray
-  type, extends(pf_encap_t) :: zndarray
+  type, extends(pf_encap_t) :: pf_zndarray_t
      integer :: ndim
-     integer,    allocatable :: shape(:)     
+     integer,    allocatable :: arr_shape(:)     
     complex(pfdp), allocatable :: flatarray(:)
   contains
     procedure :: setval => zndarray_setval
@@ -47,16 +47,16 @@ module pf_mod_zndarray
     procedure :: axpy => zndarray_axpy
     procedure :: eprint => zndarray_eprint
     procedure :: write_to_disk
-  end type zndarray
+  end type pf_zndarray_t
 
   contains
 
   function cast_as_zndarray(encap_polymorph) result(zndarray_obj)
     class(pf_encap_t), intent(in), target :: encap_polymorph
-    type(zndarray), pointer :: zndarray_obj
+    type(pf_zndarray_t), pointer :: zndarray_obj
 
     select type(encap_polymorph)
-    type is (zndarray)
+    type is (pf_zndarray_t)
        zndarray_obj => encap_polymorph
     end select
   end function cast_as_zndarray
@@ -66,14 +66,14 @@ module pf_mod_zndarray
     class(pf_encap_t), intent(inout) :: q
     integer,           intent(in   ) :: shape_in(:)
 
-    type(zndarray), pointer :: zndarray_obj
+    type(pf_zndarray_t), pointer :: zndarray_obj
 
     select type (q)
-    class is (zndarray)
-       allocate(q%shape(SIZE(shape_in)))
+    class is (pf_zndarray_t)
+       allocate(q%arr_shape(SIZE(shape_in)))
        allocate(q%flatarray(product(shape_in)))
        q%ndim   = SIZE(shape_in)
-       q%shape = shape_in
+       q%arr_shape = shape_in
        q%flatarray = cmplx(0.0, 0.0,pfdp)
        
     end select
@@ -83,11 +83,11 @@ module pf_mod_zndarray
 
   subroutine zndarray_destroy(encap)
     class(pf_encap_t), intent(inout) :: encap
-    type(zndarray), pointer :: zndarray_obj
+    type(pf_zndarray_t), pointer :: zndarray_obj
 
 
     zndarray_obj => cast_as_zndarray(encap)
-    deallocate(zndarray_obj%shape)
+    deallocate(zndarray_obj%arr_shape)
     deallocate(zndarray_obj%flatarray)
     nullify(zndarray_obj)
 
@@ -95,26 +95,26 @@ module pf_mod_zndarray
 
   !> Wrapper routine for allocation of a single zndarray type array
   subroutine zndarray_create_single(this, x, level_index,  lev_shape)
-    class(zndarray_factory), intent(inout) :: this
+    class(pf_zndarray_factory_t), intent(inout) :: this
     class(pf_encap_t), intent(inout), allocatable :: x
     integer, intent(in) :: level_index
     integer, intent(in) :: lev_shape(:)
 
-    allocate(zndarray::x)
+    allocate(pf_zndarray_t::x)
     call zndarray_build(x, lev_shape)
 
   end subroutine zndarray_create_single
 
   !> Wrapper routine for looped allocation of many zndarray type arrays
   subroutine zndarray_create_array(this, x, n, level_index,  lev_shape)
-    class(zndarray_factory), intent(inout) :: this
+    class(pf_zndarray_factory_t), intent(inout) :: this
     class(pf_encap_t), intent(inout), allocatable :: x(:)
     integer, intent(in) :: n
     integer, intent(in) :: level_index
     integer, intent(in) :: lev_shape(:)
     integer :: i
 
-    allocate(zndarray::x(n))
+    allocate(pf_zndarray_t::x(n))
     do i = 1, n
        call zndarray_build(x(i), lev_shape)
     end do
@@ -122,12 +122,12 @@ module pf_mod_zndarray
   end subroutine zndarray_create_array
 
   subroutine zndarray_destroy_single(this, x)
-    class(zndarray_factory), intent(inout) :: this
+    class(pf_zndarray_factory_t), intent(inout) :: this
     class(pf_encap_t), intent(inout), allocatable :: x
 
     select type (x)
-    class is (zndarray)
-       deallocate(x%shape)
+    class is (pf_zndarray_t)
+       deallocate(x%arr_shape)
        deallocate(x%flatarray)
     end select
     deallocate(x)
@@ -136,14 +136,14 @@ module pf_mod_zndarray
 
   !> Wrapper routine for looped allocation of many zndarray type arrays
   subroutine zndarray_destroy_array(this, x)
-    class(zndarray_factory), intent(inout)       :: this
+    class(pf_zndarray_factory_t), intent(inout)       :: this
     class(pf_encap_t), intent(inout),allocatable :: x(:)
     integer :: i
 
     select type(x)
-    class is (zndarray)
+    class is (pf_zndarray_t)
        do i = 1,SIZE(x)
-          deallocate(x(i)%shape)
+          deallocate(x(i)%arr_shape)
           deallocate(x(i)%flatarray)
        end do
     end select
@@ -154,7 +154,7 @@ module pf_mod_zndarray
 
   !> Set solution value.
   subroutine zndarray_setval(this, val, flags)
-    class(zndarray), intent(inout) :: this
+    class(pf_zndarray_t), intent(inout) :: this
     real(pfdp), intent(in) :: val
     integer, intent(in), optional :: flags
     complex(pfdp) :: zval
@@ -165,10 +165,10 @@ module pf_mod_zndarray
 
   !> Copy solution value.
   subroutine zndarray_copy(this, src, flags)
-    class(zndarray), intent(inout) :: this
+    class(pf_zndarray_t), intent(inout) :: this
     class(pf_encap_t), intent(in) :: src
     integer, intent(in), optional :: flags
-    class(zndarray), pointer :: zndarray_src
+    class(pf_zndarray_t), pointer :: zndarray_src
 
     zndarray_src => cast_as_zndarray(src)
 
@@ -177,12 +177,12 @@ module pf_mod_zndarray
 
   !> Pack solution q into a flat array.
   subroutine zndarray_pack(this, z,flags)
-    class(zndarray), intent(in) :: this
+    class(pf_zndarray_t), intent(in) :: this
     real(pfdp), intent(out) :: z(:)
     integer,     intent(in   ), optional :: flags
     integer :: i
 
-    do i = 1,product(this%shape)
+    do i = 1,product(this%arr_shape)
        z(2*i-1) = REAL(this%flatarray(i))
        z(2*i)    = AIMAG(this%flatarray(i))
     end do
@@ -190,19 +190,19 @@ module pf_mod_zndarray
 
   ! Unpack solution from a flat array.
   subroutine zndarray_unpack(this, z,flags)
-    class(zndarray), intent(inout) :: this
+    class(pf_zndarray_t), intent(inout) :: this
     real(pfdp), intent(in) :: z(:)
     integer,     intent(in   ), optional :: flags
     integer :: i
 
-    do i = 1,product(this%shape)
+    do i = 1,product(this%arr_shape)
        this%flatarray(i) = cmplx(z(2*i-1), z(2*i), pfdp)
     enddo
   end subroutine zndarray_unpack
 
   ! Compute norm of solution
   function zndarray_norm(this,flags) result (norm)
-    class(zndarray), intent(in) :: this
+    class(pf_zndarray_t), intent(in) :: this
     integer,     intent(in   ), optional :: flags
     real(pfdp) :: norm
 
@@ -211,25 +211,25 @@ module pf_mod_zndarray
 
   ! Compute y = a x + y where a is a scalar and x and y are solutions.
   subroutine zndarray_axpy(this, a, x, flags)
-    class(zndarray), intent(inout) :: this
+    class(pf_zndarray_t), intent(inout) :: this
     class(pf_encap_t), intent(in) :: x
     real(pfdp), intent(in) :: a
     integer, intent(in), optional :: flags
-    class(zndarray), pointer :: zndarray_obj
+    class(pf_zndarray_t), pointer :: zndarray_obj
 
     zndarray_obj => cast_as_zndarray(x)
     this%flatarray = a * zndarray_obj%flatarray + this%flatarray
   end subroutine zndarray_axpy
 
   subroutine zndarray_eprint(this,flags)
-    class(zndarray), intent(inout) :: this
+    class(pf_zndarray_t), intent(inout) :: this
     integer,           intent(in   ), optional :: flags
 
     print*, this%flatarray(1:2)
   end subroutine zndarray_eprint
 
   subroutine write_to_disk(this, filename)
-    class(zndarray), intent(inout) :: this
+    class(pf_zndarray_t), intent(inout) :: this
     character(len=*), intent(in) :: filename
 
     complex(pfdp),      pointer :: z_array(:,:)    
@@ -247,7 +247,7 @@ module pf_mod_zndarray
     integer,           intent(in   ), optional :: flags
     complex(pfdp), pointer :: r(:)
     select type (x)
-    type is (zndarray)
+    type is (pf_zndarray_t)
        r => x%flatarray
     end select
   end function get_array1d
@@ -259,8 +259,8 @@ module pf_mod_zndarray
     complex(pfdp), pointer :: r(:,:)
 
     select type (x)
-    type is (zndarray)
-       r(1:x%shape(1),1:x%shape(2)) => x%flatarray
+    type is (pf_zndarray_t)
+       r(1:x%arr_shape(1),1:x%arr_shape(2)) => x%flatarray
     end select
   end function get_array2d
   
@@ -271,8 +271,8 @@ module pf_mod_zndarray
     complex(pfdp), pointer :: r(:,:,:)
 
     select type (x)
-    type is (zndarray)
-       r(1:x%shape(1),1:x%shape(2),1:x%shape(3)) => x%flatarray
+    type is (pf_zndarray_t)
+       r(1:x%arr_shape(1),1:x%arr_shape(2),1:x%arr_shape(3)) => x%flatarray
     end select
   end function get_array3d
 

--- a/test/EXP_adv_diff_fft/1d/src/main.f90
+++ b/test/EXP_adv_diff_fft/1d/src/main.f90
@@ -36,8 +36,8 @@ contains
     !>  Local variables
     type(pf_pfasst_t) :: pf       !<  the main pfasst structure
     type(pf_comm_t)   :: comm     !<  the communicator (here it is mpi)
-    type(ndarray)     :: y_0      !<  the initial condition
-    type(ndarray)     :: y_end    !<  the solution at the final time
+    type(pf_ndarray_t):: y_0      !<  the initial condition
+    type(pf_ndarray_t):: y_end    !<  the solution at the final time
     character(256)    :: pf_fname   !<  file name for input parameters
 
     integer           ::  l   !  loop variable over levels
@@ -56,7 +56,7 @@ contains
     do l = 1, pf%nlevels
        !>  Allocate the user specific level object
        allocate(ad_level_t::pf%levels(l)%ulevel)
-       allocate(ndarray_factory::pf%levels(l)%ulevel%factory)
+       allocate(pf_ndarray_factory_t::pf%levels(l)%ulevel%factory)
 
        !>  Add the sweeper to the level
        allocate(ad_sweeper_t::pf%levels(l)%ulevel%sweeper)

--- a/test/EXP_adv_diff_fft/1d/src/sweeper.f90
+++ b/test/EXP_adv_diff_fft/1d/src/sweeper.f90
@@ -289,7 +289,7 @@ contains
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   !> Routine to set initial condition.
   subroutine initial(y_0)
-    type(ndarray), intent(inout) :: y_0
+    type(pf_ndarray_t), intent(inout) :: y_0
     call exact(0.0_pfdp, y_0%flatarray)
   end subroutine initial
 

--- a/test/EXP_adv_diff_fft/1d/src/sweeper.f90
+++ b/test/EXP_adv_diff_fft/1d/src/sweeper.f90
@@ -69,7 +69,7 @@ contains
         
 
       lev => pf%levels(level_index)
-      this%nx=lev%shape(1)
+      this%nx=lev%lev_shape(1)
       nx=this%nx
       nnodes=lev%nnodes
 
@@ -123,14 +123,14 @@ contains
   ! ==================================================================
 
      !F_EVAL: evaluates the nonlinear function N(t,y(t)) at y, t.
-     subroutine f_eval(this, y, t, level, n)
+     subroutine f_eval(this, y, t, level_index, n)
         use probin, only:  splitting, v,nu
 
         ! arguments
         class(ad_sweeper_t), intent(inout) :: this
         class(pf_encap_t),   intent(in)    :: y
         real(pfdp),          intent(in)    :: t
-        integer,             intent(in)    :: level
+        integer,             intent(in)    :: level_index
         class(pf_encap_t),   intent(inout) :: n
 
         ! local variables

--- a/test/adv_diff_fft/1d/multi_level.nml
+++ b/test/adv_diff_fft/1d/multi_level.nml
@@ -37,7 +37,7 @@
 !  Now define the local variables you need
 &PARAMS
 
-    nx =  16 32 64
+    nx =  16 32 32
     nu = 0.02
     v=1.0
 

--- a/test/adv_diff_fft/1d/src/hooks.f90
+++ b/test/adv_diff_fft/1d/src/hooks.f90
@@ -15,7 +15,7 @@ contains
     type(pf_pfasst_t), intent(inout) :: pf
     integer, intent(in) :: level_index
 
-    real(pfdp) :: yexact(pf%levels(level_index)%shape(1))
+    real(pfdp) :: yexact(pf%levels(level_index)%lev_shape(1))
     real(pfdp), pointer :: y_end(:)
     real(pfdp) :: maxerr
     real(pfdp) :: residual
@@ -23,7 +23,6 @@ contains
     !>  compute the error at last end point
     y_end => get_array1d(pf%levels(level_index)%qend)
     call exact(pf%state%t0+pf%state%dt, yexact)
-
 
     maxerr = maxval(abs(y_end-yexact))
     residual=pf%levels(level_index)%residual

--- a/test/adv_diff_fft/1d/src/level.f90
+++ b/test/adv_diff_fft/1d/src/level.f90
@@ -58,7 +58,6 @@ contains
        return
     elseif (irat == 2) then  !  Use spectral space
        call fft_c%interp(yvec_c,fft_f,yvec_f)
-       print *,'max',maxval(yvec_c),maxval(yvec_f)
     end if
 
   end subroutine interpolate

--- a/test/adv_diff_fft/1d/src/main.f90
+++ b/test/adv_diff_fft/1d/src/main.f90
@@ -36,8 +36,8 @@ contains
     !>  Local variables
     type(pf_pfasst_t) :: pf       !<  the main pfasst structure
     type(pf_comm_t)   :: comm     !<  the communicator (here it is mpi)
-    type(ndarray)     :: y_0      !<  the initial condition
-    type(ndarray)     :: y_end    !<  the solution at the final time
+    type(pf_ndarray_t):: y_0      !<  the initial condition
+    type(pf_ndarray_t):: y_end    !<  the solution at the final time
     character(256)    :: pf_fname   !<  file name for input of PFASST parameters
 
     integer           ::  l   !  loop variable over levels
@@ -57,7 +57,7 @@ contains
        allocate(ad_level_t::pf%levels(l)%ulevel)
 
        !>  Allocate the user specific data factory
-       allocate(ndarray_factory::pf%levels(l)%ulevel%factory)
+       allocate(pf_ndarray_factory_t::pf%levels(l)%ulevel%factory)
 
        !>  Add the sweeper to the level
        allocate(ad_sweeper_t::pf%levels(l)%ulevel%sweeper)

--- a/test/adv_diff_fft/1d/src/sweeper.f90
+++ b/test/adv_diff_fft/1d/src/sweeper.f90
@@ -71,7 +71,7 @@ contains
        this%explicit=.TRUE.
     end if
 
-    nx=pf%levels(level_index)%shape(1)  !  local convenient grid size
+    nx=pf%levels(level_index)%lev_shape(1)  !  local convenient grid size
 
     !>  Set up the FFT 
     allocate(this%fft_tool)

--- a/test/adv_diff_fft/1d/src/sweeper.f90
+++ b/test/adv_diff_fft/1d/src/sweeper.f90
@@ -213,7 +213,7 @@ contains
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   !> Routine to set initial condition.
   subroutine initial_sol(y_0)
-    type(ndarray), intent(inout) :: y_0
+    type(pf_ndarray_t), intent(inout) :: y_0
     call exact(0.0_pfdp, y_0%flatarray)
   end subroutine initial_sol
 

--- a/test/adv_diff_fft/2d/src/hooks.f90
+++ b/test/adv_diff_fft/2d/src/hooks.f90
@@ -16,7 +16,7 @@ contains
 
     real(pfdp), pointer :: y_end(:,:),y_ex(:,:)
     real(pfdp) :: maxerr
-    type(ndarray), target :: y_exact      !<  the initial condition
+    type(pf_ndarray_t), target :: y_exact      !<  the initial condition
     y_end => get_array2d(pf%levels(level_index)%qend)
     call ndarray_build(y_exact, [ pf%levels(level_index)%lev_shape])
     y_ex => get_array2d(y_exact)    

--- a/test/adv_diff_fft/2d/src/hooks.f90
+++ b/test/adv_diff_fft/2d/src/hooks.f90
@@ -18,7 +18,7 @@ contains
     real(pfdp) :: maxerr
     type(ndarray), target :: y_exact      !<  the initial condition
     y_end => get_array2d(pf%levels(level_index)%qend)
-    call ndarray_build(y_exact, [ pf%levels(level_index)%shape])
+    call ndarray_build(y_exact, [ pf%levels(level_index)%lev_shape])
     y_ex => get_array2d(y_exact)    
     
     !>  compute the exact solution

--- a/test/adv_diff_fft/2d/src/main.f90
+++ b/test/adv_diff_fft/2d/src/main.f90
@@ -36,8 +36,8 @@ contains
     !>  Local variables
     type(pf_pfasst_t) :: pf       !<  the main pfasst structure
     type(pf_comm_t)   :: comm     !<  the communicator (here it is mpi)
-    type(ndarray)     :: y_0      !<  the initial condition
-    type(ndarray)     :: y_end    !<  the solution at the final time
+    type(pf_ndarray_t):: y_0      !<  the initial condition
+    type(pf_ndarray_t):: y_end    !<  the solution at the final time
     character(256)    :: pf_fname   !<  file name for input of PFASST parameters
 
     integer           ::  l   !  loop variable over levels
@@ -55,7 +55,7 @@ contains
     do l = 1, pf%nlevels
        !>  Allocate the user specific level object
        allocate(ad_level_t::pf%levels(l)%ulevel)
-       allocate(ndarray_factory::pf%levels(l)%ulevel%factory)
+       allocate(pf_ndarray_factory_t::pf%levels(l)%ulevel%factory)
 
        !>  Add the sweeper to the level
        allocate(ad_sweeper_t::pf%levels(l)%ulevel%sweeper)

--- a/test/adv_diff_fft/2d/src/main.f90
+++ b/test/adv_diff_fft/2d/src/main.f90
@@ -79,8 +79,8 @@ contains
     call print_loc_options(pf,un_opt=6)
     
     !> allocate initial and final solutions
-    call ndarray_build(y_0, [ pf%levels(pf%nlevels)%shape])
-    call ndarray_build(y_end, [ pf%levels(pf%nlevels)%shape])
+    call ndarray_build(y_0, [ pf%levels(pf%nlevels)%lev_shape])
+    call ndarray_build(y_end, [ pf%levels(pf%nlevels)%lev_shape])
 
     !> compute initial condition
     call initial(y_0)

--- a/test/adv_diff_fft/2d/src/sweeper.f90
+++ b/test/adv_diff_fft/2d/src/sweeper.f90
@@ -56,8 +56,8 @@ contains
     complex(pfdp), allocatable :: ddx(:,:) ! First derivative operators
     complex(pfdp), allocatable :: ddy(:,:) ! First derivative operators
     
-    nx=pf%levels(level_index)%shape(1)
-    ny=pf%levels(level_index)%shape(2)
+    nx=pf%levels(level_index)%lev_shape(1)
+    ny=pf%levels(level_index)%lev_shape(2)
     
     !  Call the imex sweeper initialize
     call this%imex_initialize(pf,level_index)

--- a/test/adv_diff_fft/2d/src/sweeper.f90
+++ b/test/adv_diff_fft/2d/src/sweeper.f90
@@ -199,7 +199,7 @@ contains
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   !> Routine to set initial condition.
   subroutine initial(y_0)
-    type(ndarray), intent(inout) :: y_0
+    type(pf_ndarray_t), intent(inout) :: y_0
     real(pfdp), pointer :: yvec(:,:)
     yvec => get_array2d(y_0)    
     call exact(0.0_pfdp, yvec)

--- a/test/imk/src/factory.f90
+++ b/test/imk/src/factory.f90
@@ -79,26 +79,26 @@ module mod_zmkpair
   end subroutine zmkpair_destroy
 
   !> Wrapper routine for allocation of a single zmkpair type array
-  subroutine zmkpair_create_single(this, x, level, shape)
+  subroutine zmkpair_create_single(this, x, level_index, lev_shape)
     class(zmkpair_factory), intent(inout) :: this
     class(pf_encap_t), intent(inout), allocatable :: x
-    integer, intent(in) :: level, shape(:)
+    integer, intent(in) :: level_index, lev_shape(:)
 
     allocate(zmkpair::x)
-    call zmkpair_build(x, shape(1))
+    call zmkpair_build(x, lev_shape(1))
 
   end subroutine zmkpair_create_single
 
   !> Wrapper routine for looped allocation of many zmkpair type arrays
-  subroutine zmkpair_create_array(this, x, n, level, shape)
+  subroutine zmkpair_create_array(this, x, n, level_index, lev_shape)
     class(zmkpair_factory), intent(inout) :: this
     class(pf_encap_t), intent(inout), allocatable :: x(:)
-    integer, intent(in) :: n, level, shape(:)
+    integer, intent(in) :: n, level_index, lev_shape(:)
     integer :: i
 
     allocate(zmkpair::x(n))
     do i = 1, n
-       call zmkpair_build(x(i), shape(1))
+       call zmkpair_build(x(i), lev_shape(1))
     end do
 
   end subroutine zmkpair_create_array

--- a/test/imk/src/main.f90
+++ b/test/imk/src/main.f90
@@ -73,8 +73,8 @@ contains
       !>  output the run options 
       call pf_print_options(pf,un_opt=6)
       
-      call zmkpair_build(q0, pf%levels(pf%nlevels)%shape(1))
-      call zmkpair_build(qend, pf%levels(pf%nlevels)%shape(1))
+      call zmkpair_build(q0, pf%levels(pf%nlevels)%lev_shape(1))
+      call zmkpair_build(qend, pf%levels(pf%nlevels)%lev_shape(1))
       call initial(q0)
 
       call mpi_barrier(MPI_COMM_WORLD, err)

--- a/test/magpicard/src/hooks.f90
+++ b/test/magpicard/src/hooks.f90
@@ -12,8 +12,8 @@ contains
     integer,  intent(in   ) :: level_index
 
     class(magpicard_sweeper_t), pointer :: magpicard
-    type(zndarray) :: yexact
-    type(zndarray), pointer :: qend
+    type(pf_zndarray_t) :: yexact
+    type(pf_zndarray_t), pointer :: qend
     integer :: dim(2)
     real(pfdp) :: errd,t_end
     complex(pfdp),      pointer :: q_array(:,:)
@@ -51,7 +51,7 @@ contains
     type(pf_pfasst_t), intent(inout) :: pf
     integer, intent(in) :: level_index
 
-    type(zndarray), pointer :: qend,Fend
+    type(pf_zndarray_t), pointer :: qend,Fend
     character(len=256) :: time, filename
     integer :: un,istat,system
     complex(pfdp),      pointer :: q_array(:,:)

--- a/test/magpicard/src/main.f90
+++ b/test/magpicard/src/main.f90
@@ -24,7 +24,7 @@ contains
       type(pf_pfasst_t)  :: pf          !< pfasst data structure
       type(pf_comm_t)    :: comm        !< mpi communicator
 
-      type(zndarray) :: dmat_t0, dmat_tfinal
+      type(pf_zndarray_t) :: dmat_t0, dmat_tfinal
 
       character(256) :: probin_fname       !<  file name for input
       integer    :: err, l
@@ -44,7 +44,7 @@ contains
       do l = 1, pf%nlevels
           !  Allocate level structures
           allocate(magpicard_context::pf%levels(l)%ulevel)
-          allocate(zndarray_factory::pf%levels(l)%ulevel%factory)
+          allocate(pf_zndarray_factory_t::pf%levels(l)%ulevel%factory)
           allocate(magpicard_sweeper_t::pf%levels(l)%ulevel%sweeper)
 
           !  Set level size

--- a/test/magpicard/src/utils.f90
+++ b/test/magpicard/src/utils.f90
@@ -16,13 +16,13 @@ module utils
   subroutine initial(L)
 
     class(pf_encap_t), intent(inout) :: L
-    class(zndarray), pointer :: L_p
+    class(pf_zndarray_t), pointer :: L_p
     complex(pfdp),      pointer :: L_array(:,:)
     integer :: Nmat
     
     L_p => cast_as_zndarray(L)
     L_array=>get_array2d(L)
-    Nmat = L_p%shape(1) !  Assumes a square matrix
+    Nmat = L_p%arr_shape(1) !  Assumes a square matrix
 
     select case(nprob)
     case (1)
@@ -124,13 +124,13 @@ module utils
   end subroutine init_Facke
   
   
-  subroutine compute_F_toda(L_array,B_array,Nmat,t,level)
+  subroutine compute_F_toda(L_array,B_array,Nmat,t,level_index)
     use probin, only: toda_periodic
     ! RHS for Toda lattice problem
     complex(pfdp), intent(inout),  pointer :: L_array(:,:), B_array(:,:)
     integer,intent(in) :: Nmat
     real(pfdp), intent(in) :: t
-    integer, intent(in) :: level
+    integer, intent(in) :: level_index
     
     integer :: i
 
@@ -152,14 +152,14 @@ module utils
   end subroutine compute_F_toda
   
   
-  subroutine compute_Facke(L_array,B_array,Nmat,t,level)
+  subroutine compute_Facke(L_array,B_array,Nmat,t,level_index)
     use probin, only: Znuc,E0,Xmax
 
     !  RHS for fake Fock matrix example
     complex(pfdp), intent(inout),  pointer :: L_array(:,:), B_array(:,:)
     integer,intent(in) :: Nmat
     real(pfdp), intent(in) :: t
-    integer, intent(in) :: level
+    integer, intent(in) :: level_index
     
     integer :: i,j,n,m
     real(pfdp) :: xi,xj,xn,xm,cst,dx

--- a/test/nagumo/src/feval.f90
+++ b/test/nagumo/src/feval.f90
@@ -277,7 +277,7 @@ contains
     integer,             intent(in)    :: level_index
     
     integer  :: nx, nnodes
-    nx=pf%levels(level_index)%shape(1)
+    nx=pf%levels(level_index)%lev_shape(1)
     nnodes=pf%levels(level_index)%nnodes
 
     !  Call the imex sweeper initialize
@@ -397,7 +397,7 @@ contains
     class(ad_sweeper_t), pointer :: sweeper
     sweeper => as_ad_sweeper(s)
 
-    nvars = product(pf%levels(pf%nlevels)%shape)
+    nvars = product(pf%levels(pf%nlevels)%lev_shape)
     nnodes = size(nodes,1)
 
     allocate(uexact(nvars))

--- a/test/nagumo/src/main_split.f90
+++ b/test/nagumo/src/main_split.f90
@@ -146,7 +146,7 @@ program main
   end if
 
 
-  call ndarray_oc_build(q1, pf%levels(pf%nlevels)%shape)
+  call ndarray_oc_build(q1, pf%levels(pf%nlevels)%lev_shape)
   do l = 1, pf%nlevels
      call initialize_oc(pf%levels(l)%ulevel%sweeper, pf%rank*dt, dt, pf%levels(l)%nodes, nvars(l), alpha)
   end do

--- a/test/nagumo/src/pf_optimization.f90
+++ b/test/nagumo/src/pf_optimization.f90
@@ -87,7 +87,7 @@ contains
     do m = 1, pf%levels(pf%nlevels)%nnodes
 !       if (pf%rank .eq. 0) print *, m
       call objective_function(pf%levels(pf%nlevels)%ulevel%sweeper, pf%levels(pf%nlevels)%Q(m), &
-                                    product(pf%levels(pf%nlevels)%shape), m, obj(m))
+                                    product(pf%levels(pf%nlevels)%lev_shape), m, obj(m))
     end do
     objective = 0.0
     do m = 1, pf%levels(pf%nlevels)%nnodes-1
@@ -96,7 +96,7 @@ contains
     end do
     objective = 0.5*objective !0.5 for trapezoidal rule
     call control_L2Q(pf%levels(pf%nlevels)%ulevel%sweeper, dt, pf%levels(pf%nlevels)%nodes, &
-                                  product(pf%levels(pf%nlevels)%shape), L2NormUSq)
+                                  product(pf%levels(pf%nlevels)%lev_shape), L2NormUSq)
     objective = 0.5*objective + 0.5*alpha*L2NormUSq
     deallocate(obj)
   end subroutine evaluate_objective


### PR DESCRIPTION
This is a mostly cosmetic update in attempt to make the variable names more consistent.  Some differences (check the commit comments for more)

Renamed lev_shape and arr_shape so that there are no variables named the same as Fortran instrinsics.

Made level_index the default for the integer lev%index

Renamed encap types and factories to match the pf_*_t convention

Made local level pointer variables consistent , ie. f_lev, c_lev

Removed dble intrinsic in favor of real(*,pfdp)

Capiltalized intrinsics like SHAPE, SIZE