### PR TITLE
Newtimers

### DIFF
--- a/.depend
+++ b/.depend
@@ -14,7 +14,7 @@
 ./build/pf_rkstepper.o : src/pf_rkstepper.f90 ./build/pf_hooks.o ./build/pf_timer.o ./build/pf_utils.o ./build/pf_dtype.o 
 ./build/pf_solutions.o : src/pf_solutions.f90 ./build/pf_dtype.o 
 ./build/pf_stop.o : src/pf_stop.f90 
-./build/pf_timer.o : src/pf_timer.f90 ./build/pf_mpi.o ./build/pf_dtype.o 
+./build/pf_timer.o : src/pf_timer.f90 ./build/pf_mpi.o ./build/pf_stop.o ./build/pf_dtype.o 
 ./build/pf_utils.o : src/pf_utils.f90 ./build/pf_stop.o ./build/pf_timer.o ./build/pf_dtype.o 
 ./build/pf_ndarray_encap.o : src/pf_ndarray_encap.f90 ./build/pf_stop.o ./build/pf_dtype.o 
 ./build/pf_ndarray_oc_encap.o : src/pf_ndarray_oc_encap.f90 ./build/pf_utils.o ./build/pf_dtype.o 

--- a/Tutorials/EX3_adv_diff/multi_level.nml
+++ b/Tutorials/EX3_adv_diff/multi_level.nml
@@ -30,7 +30,6 @@
 
 
      save_residuals=.false.
-     save_timings=.false.
      use_Sform=.true.
 /
 

--- a/src/pf_amisdc_sweeper.f90
+++ b/src/pf_amisdc_sweeper.f90
@@ -90,7 +90,8 @@ contains
     real(pfdp)                        :: dtsdc(1:lev%nnodes-1)
     class(pf_encap_t), allocatable    :: rhsA, rhsB, QA, QB
 
-    call start_timer(pf, TLEVEL+lev%index-1)
+
+    if (pf%save_timings > 1) call pf_start_timer(pf, T_SWEEP,lev%index)
     
     ! compute integrals and add fas correction
     do m = 1, lev%nnodes-1
@@ -160,7 +161,7 @@ contains
     call lev%ulevel%factory%destroy_single(QA,   lev%index,  lev%lev_shape)
     call lev%ulevel%factory%destroy_single(QB,   lev%index,  lev%lev_shape)
 
-    call end_timer(pf, TLEVEL+lev%index-1)
+    if (pf%save_timings > 1) call pf_stop_timer(pf, T_SWEEP,lev%index)
 
   end subroutine amisdc_sweep
      

--- a/src/pf_amisdc_sweeperQ.f90
+++ b/src/pf_amisdc_sweeperQ.f90
@@ -42,7 +42,8 @@ contains
     class(pf_encap_t), allocatable :: rhsA, rhsB, QA, QB
     class(pf_encap_t), allocatable :: S2(:), S3(:)
 
-    call start_timer(pf, TLEVEL+lev%index-1)
+
+    if (pf%save_timings > 1) call pf_start_timer(pf, T_SWEEP,lev%index)
    
     call lev%ulevel%factory%create_array(S2,lev%nnodes-1,lev%index,lev%lev_shape)
     call lev%ulevel%factory%create_array(S3,lev%nnodes-1,lev%index,lev%lev_shape)
@@ -130,7 +131,8 @@ contains
     call lev%ulevel%factory%destroy_single(QA)
     call lev%ulevel%factory%destroy_single(QB)
 
-    call end_timer(pf, TLEVEL+lev%index-1)
+    if (pf%save_timings > 1) call pf_stop_timer(pf, T_SWEEP,lev%index)
+
 
   end subroutine sweep_coupled_implicit_terms
 
@@ -240,7 +242,6 @@ contains
     ! call lev%ulevel%factory%destroy_single(QA,   lev%index,   lev%lev_shape)
     ! call lev%ulevel%factory%destroy_single(QB,   lev%index,   lev%lev_shape)
 
-    ! call end_timer(pf, TLEVEL+lev%index-1)
         
   end subroutine sweep_decoupled_implicit_terms
 

--- a/src/pf_dtype.f90
+++ b/src/pf_dtype.f90
@@ -244,6 +244,28 @@ module pf_mod_dtype
 
   end type pf_results_t
 
+  !>  Type for storing timings  later output
+  type :: pf_timer_t
+     real(pfdp) :: t_total= 0.0_pfdp
+     real(pfdp) :: t_predictor= 0.0_pfdp
+     real(pfdp) :: t_iteration= 0.0_pfdp
+     real(pfdp) :: t_broadcast = 0.0_pfdp
+     real(pfdp) :: t_step= 0.0_pfdp
+     real(pfdp) :: t_hooks(PF_MAXLEVS) = 0.0_pfdp
+     real(pfdp) :: t_sweeps(PF_MAXLEVS) = 0.0_pfdp
+     real(pfdp) :: t_aux(PF_MAXLEVS) = 0.0_pfdp
+     real(pfdp) :: t_residual(PF_MAXLEVS) = 0.0_pfdp
+     real(pfdp) :: t_interpolate(PF_MAXLEVS) = 0.0_pfdp
+     real(pfdp) :: t_restrict(PF_MAXLEVS) = 0.0_pfdp
+     real(pfdp) :: t_wait(PF_MAXLEVS) = 0.0_pfdp
+     real(pfdp) :: t_send(PF_MAXLEVS) = 0.0_pfdp
+     real(pfdp) :: t_receive(PF_MAXLEVS) = 0.0_pfdp
+     real(pfdp) :: t_feval(PF_MAXLEVS) = 0.0_pfdp
+     real(pfdp) :: t_fcomp(PF_MAXLEVS) = 0.0_pfdp
+
+  end type pf_timer_t
+  
+
   !>  The main PFASST data type which includes pretty much everythingl
   type :: pf_pfasst_t
      !> === Mandatory pfasst parameters (must be set on command line or input file)  ===
@@ -281,7 +303,7 @@ module pf_mod_dtype
      logical :: Finterp = .false.    !!  True if transfer functions operate on rhs
      logical :: use_LUq = .true.     !!  True if LU type implicit matrix is used
      logical :: use_Sform = .false.  !!  True if Qmat type of stepping is used
-     integer :: taui0 = -999999      !! iteration cutoff for tau inclusion
+     integer :: taui0 = -99          !! iteration cutoff for tau inclusion
 
 
      ! -- RK and Parareal options
@@ -294,8 +316,7 @@ module pf_mod_dtype
 
      ! -- controller for the results 
      logical :: save_residuals = .false.  !!  If true, residuals are saved and output
-     logical :: save_timings  = .false.    !!  If true, timings are saved and  output
-     logical :: echo_timings  = .false.    !!  If true, timings are  output to screen
+     integer :: save_timings  = 2         !!  0=none, 1=total only, 2=all, 3=all and echo
      logical :: save_errors  = .false.    !!  If true, errors  are saved and output
 
      integer :: rank    = -1            !! rank of current processor
@@ -305,15 +326,14 @@ module pf_mod_dtype
      type(pf_level_t), allocatable :: levels(:) !! Holds the levels
      type(pf_comm_t),  pointer :: comm    !! Points to communicator
      type(pf_results_t),allocatable :: results(:)   !!  Hold results for each level
-
+ 
      !> hooks variables
      type(pf_hook_t), allocatable :: hooks(:,:,:)  !!  Holds the hooks
      integer,  allocatable :: nhooks(:,:)   !!  Holds the number hooks
 
      !> timing variables
-     double precision :: timers(100)   = 0.0d0
-     double precision :: runtimes(100) = 0.0d0
-
+     type(pf_timer_t) :: pf_timers
+     type(pf_timer_t) :: pf_runtimes
      !> output directory
      character(len=256) :: outdir
 

--- a/src/pf_exp_sweeper.f90
+++ b/src/pf_exp_sweeper.f90
@@ -276,18 +276,21 @@ type, extends(pf_sweeper_t), abstract :: pf_exp_t
 
         lev => pf%levels(level_index)
         nnodes = lev%nnodes
-        call start_timer(pf, TLEVEL+lev%index-1)        
         ! error sweeps
         do k = 1, nsweeps
+           call call_hooks(pf, level_index, PF_PRE_SWEEP)   
+           if (pf%save_timings > 1) call pf_start_timer(pf, T_SWEEP,level_index)        
+           
            pf%state%sweep=k                  
-
-           call call_hooks(pf, level_index, PF_PRE_SWEEP)      ! NOTE: ensure that lev%F has been properly initialized here
+           ! NOTE: ensure that lev%F has been properly initialized here
            do j = 1, nnodes
               call this%f_old(j)%copy(lev%F(j,1))  ! Save old f
            end do
            if (k .eq. 1) then
-              call lev%Q(1)%copy(lev%q0)  
-              call this%f_eval(lev%Q(1), t0, lev%index, lev%F(1,1))      ! compute F_j^{[k+1]}
+              call lev%Q(1)%copy(lev%q0)
+              if (pf%save_timings > 1) call pf_start_timer(pf, T_FEVAL,level_index)
+              call this%f_eval(lev%Q(1), t0, level_index, lev%F(1,1))      ! compute F_j^{[k+1]}
+              if (pf%save_timings > 1) call pf_stop_timer(pf, T_FEVAL,level_index)
            end if
            t = t0 
            do j = 1, nnodes - 1
@@ -297,8 +300,9 @@ type, extends(pf_sweeper_t), abstract :: pf_exp_t
               call this%b(1)%copy(lev%Q(j))  ! add term \phi_0(tL) y_n
 
               call this%b(2)%axpy(REAL(-1.0, pfdp), this%f_old(j))         ! add -\phi_1(tL) F_j^{[k]}
-              call this%f_eval(lev%Q(j), t, lev%index, lev%F(j,1))      ! compute F_j^{[k+1]}
-
+              if (pf%save_timings > 1) call pf_start_timer(pf, T_FEVAL,level_index)
+              call this%f_eval(lev%Q(j), t, level_index, lev%F(j,1))      ! compute F_j^{[k+1]}
+              if (pf%save_timings > 1) call pf_stop_timer(pf, T_FEVAL,level_index)
               call this%b(2)%axpy(REAL(1.0, pfdp), lev%F(j,1))          ! add \phi_1(tL) F_j^{[k+1]}
 
 
@@ -319,14 +323,17 @@ type, extends(pf_sweeper_t), abstract :: pf_exp_t
               end if
 
            end do  !  Substepping over nodes
-           call this%f_eval(lev%Q(nnodes), t0 + dt, lev%index, lev%F(nnodes,1))   ! eval last nonlinear term
+           if (pf%save_timings > 1) call pf_start_timer(pf, T_FEVAL,level_index)
+           call this%f_eval(lev%Q(nnodes), t0 + dt, level_index, lev%F(nnodes,1))   ! eval last nonlinear term
+           if (pf%save_timings > 1) call pf_stop_timer(pf, T_FEVAL,level_index)
+           
 
            call pf_residual(pf, level_index, dt)
            call lev%qend%copy(lev%Q(lev%nnodes))
+           if (pf%save_timings > 1) call pf_stop_timer(pf, T_SWEEP,level_index)                
            call call_hooks(pf, level_index, PF_POST_SWEEP)
            
         end do  !  Sweeps
-        call end_timer(pf, TLEVEL+lev%index-1)                
     end subroutine exp_sweep
 
     ! =================================================================================
@@ -450,8 +457,9 @@ type, extends(pf_sweeper_t), abstract :: pf_exp_t
 
       type(pf_level_t), pointer :: lev
       lev => pf%levels(level_index)   !  Assign level pointer
-      call this%f_eval(lev%Q(m), t, lev%index, lev%F(m,1))
-
+      if (pf%save_timings > 1) call pf_start_timer(pf, T_FEVAL,level_index)      
+      call this%f_eval(lev%Q(m), t, level_index, lev%F(m,1))
+      if (pf%save_timings > 1) call pf_stop_timer(pf, T_FEVAL,level_index)
     end subroutine exp_evaluate
 
     ! EVALUATE_ALL: evaluate the nonlinear term at all nodes =================

--- a/src/pf_hooks.f90
+++ b/src/pf_hooks.f90
@@ -85,7 +85,6 @@ contains
     integer :: l  !!  level loop index
 
 
-
     pf%state%hook = hook
     if (level_index == -1) then  ! Do to all levels
        do l = 1, pf%nlevels
@@ -101,10 +100,9 @@ contains
           call pf%hooks(level_index,hook,i)%proc(pf,level_index)
        end do
        if (pf%save_timings > 1) call pf_stop_timer(pf, T_HOOKS,level_index)
-       
     end if
 
-    if (pf%save_timings > 1) call pf_stop_timer(pf, T_HOOKS,level_index)
+
     
   end subroutine call_hooks
 

--- a/src/pf_hooks.f90
+++ b/src/pf_hooks.f90
@@ -84,7 +84,7 @@ contains
     integer :: i  !!  hook loop index
     integer :: l  !!  level loop index
 
-    call start_timer(pf, THOOKS)
+    if (pf%save_timings > 1) call pf_start_timer(pf, T_HOOKS,level_index)
 
     pf%state%hook = hook
     if (level_index == -1) then  ! Do to all levels
@@ -99,7 +99,8 @@ contains
        end do
     end if
 
-    call end_timer(pf, THOOKS)
+    if (pf%save_timings > 1) call pf_stop_timer(pf, T_HOOKS,level_index)
+    
   end subroutine call_hooks
 
   !>  Subroutine defining log hook

--- a/src/pf_hooks.f90
+++ b/src/pf_hooks.f90
@@ -84,19 +84,24 @@ contains
     integer :: i  !!  hook loop index
     integer :: l  !!  level loop index
 
-    if (pf%save_timings > 1) call pf_start_timer(pf, T_HOOKS,level_index)
+
 
     pf%state%hook = hook
     if (level_index == -1) then  ! Do to all levels
        do l = 1, pf%nlevels
+          if (pf%save_timings > 1) call pf_start_timer(pf, T_HOOKS,l)
           do i = 1, pf%nhooks(l,hook)
              call pf%hooks(l,hook,i)%proc(pf,l)
           end do
+          if (pf%save_timings > 1) call pf_stop_timer(pf, T_HOOKS,l)
        end do
     else  ! Do to just level level_index
+       if (pf%save_timings > 1) call pf_start_timer(pf, T_HOOKS,level_index)
        do i = 1, pf%nhooks(level_index,hook)
           call pf%hooks(level_index,hook,i)%proc(pf,level_index)
        end do
+       if (pf%save_timings > 1) call pf_stop_timer(pf, T_HOOKS,level_index)
+       
     end if
 
     if (pf%save_timings > 1) call pf_stop_timer(pf, T_HOOKS,level_index)

--- a/src/pf_imk_sweeper.f90
+++ b/src/pf_imk_sweeper.f90
@@ -137,24 +137,32 @@ contains
     call call_hooks(pf, 1, PF_PRE_SWEEP)
 
     call lev%Q(1)%copy(lev%q0, flags=1)
-    call this%f_eval(lev%Q(1), t, lev%index, this%A(1))
+    if (pf%save_timings > 1) call pf_start_timer(pf,T_FEVAL,level_index)       
+    call this%f_eval(lev%Q(1), t, level_index, this%A(1))
+    if (pf%save_timings > 1) call pf_stop_timer(pf,T_FEVAL,level_index)       
     ! commutator_p flags=1 hack copies Q(1)%y -> Q(1)%array
     ! all subsequent RK stages are done on Q(m)%array
     call this%commutator_p(this%A(1), lev%Q(1), lev%F(1,1), flags=1)
 
     call lev%Q(2)%axpy(1.0_pfdp, lev%Q(1))
     call lev%Q(2)%axpy(0.5_pfdp*dt, lev%F(1,1))
-    call this%f_eval(lev%Q(2), t, lev%index, this%A(2))
+    if (pf%save_timings > 1) call pf_start_timer(pf,T_FEVAL,level_index)       
+    call this%f_eval(lev%Q(2), t, level_index, this%A(2))
+    if (pf%save_timings > 1) call pf_stop_timer(pf,T_FEVAL,level_index)       
     call this%commutator_p(this%A(2), lev%Q(2), lev%F(2,1))
 
     call lev%Q(3)%axpy(1.0_pfdp, lev%Q(1))
     call lev%Q(3)%axpy(0.5_pfdp*dt, lev%F(2,1))
-    call this%f_eval(lev%Q(3), t, lev%index, this%A(3))
+    if (pf%save_timings > 1) call pf_start_timer(pf,T_FEVAL,level_index)       
+    call this%f_eval(lev%Q(3), t, level_index, this%A(3))
+    if (pf%save_timings > 1) call pf_stop_timer(pf,T_FEVAL,level_index)       
     call this%commutator_p(this%A(3), lev%Q(3), lev%F(3,1))
 
     call lev%Q(4)%axpy(1.0_pfdp, lev%Q(1))
     call lev%Q(4)%axpy(dt, lev%F(3,1))
-    call this%f_eval(lev%Q(4), t, lev%index, this%A(4))
+    if (pf%save_timings > 1) call pf_start_timer(pf,T_FEVAL,level_index)       
+    call this%f_eval(lev%Q(4), t, level_index, this%A(4))
+    if (pf%save_timings > 1) call pf_stop_timer(pf,T_FEVAL,level_index)       
     call this%commutator_p(this%A(4), lev%Q(4), lev%F(4,1))
 
     call lev%Q(5)%axpy(1.0_pfdp, lev%Q(1))
@@ -206,22 +214,30 @@ contains
     call call_hooks(pf, 1, PF_PRE_SWEEP)
 
     call lev%Q(1)%copy(lev%q0, flags=1)
-    call this%f_eval(lev%Q(1), t, lev%index, this%A(1))
+    if (pf%save_timings > 1) call pf_start_timer(pf,T_FEVAL,level_index)       
+    call this%f_eval(lev%Q(1), t, level_index, this%A(1))
+    if (pf%save_timings > 1) call pf_stop_timer(pf,T_FEVAL,level_index)       
     call this%dexpinv(this%A(1), lev%Q(1), lev%F(1,1))
 
     call lev%Q(2)%axpy(0.5_pfdp*dt, lev%F(1,1))
     call this%propagate(lev%q0, lev%Q(2))
-    call this%f_eval(lev%Q(2), t, lev%index, this%A(2))
+    if (pf%save_timings > 1) call pf_start_timer(pf,T_FEVAL,level_index)       
+    call this%f_eval(lev%Q(2), t, level_index, this%A(2))
+    if (pf%save_timings > 1) call pf_stop_timer(pf,T_FEVAL,level_index)       
     call this%dexpinv(this%A(2), lev%Q(2), lev%F(2,1))
 
     call lev%Q(3)%axpy(0.5_pfdp*dt, lev%F(2,1))
     call this%propagate(lev%q0, lev%Q(3))
-    call this%f_eval(lev%Q(3), t, lev%index, this%A(3))
+    if (pf%save_timings > 1) call pf_start_timer(pf,T_FEVAL,level_index)       
+    call this%f_eval(lev%Q(3), t, level_index, this%A(3))
+    if (pf%save_timings > 1) call pf_stop_timer(pf,T_FEVAL,level_index)       
     call this%dexpinv(this%A(3), lev%Q(3), lev%F(3,1))
 
     call lev%Q(4)%axpy(dt, lev%F(3,1))
     call this%propagate(lev%q0, lev%Q(4))
-    call this%f_eval(lev%Q(4), t, lev%index, this%A(4))
+    if (pf%save_timings > 1) call pf_start_timer(pf,T_FEVAL,level_index)       
+    call this%f_eval(lev%Q(4), t, level_index, this%A(4))
+    if (pf%save_timings > 1) call pf_stop_timer(pf,T_FEVAL,level_index)       
     call this%dexpinv(this%A(4), lev%Q(4), lev%F(4,1))
 
     call lev%Q(5)%axpy(dt/6.0_pfdp, lev%F(1,1))
@@ -256,11 +272,11 @@ contains
     real(pfdp)  :: t        !!  Time at nodes
     lev => pf%levels(level_index)   !  Assign level pointer
 
-    call start_timer(pf, TLEVEL+lev%index-1)
 
     do k = 1,nsweeps   !!  Loop over sweeps
-       pf%state%sweep=k
        call call_hooks(pf, level_index, PF_PRE_SWEEP)
+       if (pf%save_timings > 1) call pf_start_timer(pf, T_SWEEP,level_index)
+       pf%state%sweep=k
        ! compute integrals and add fas correction
        do m = 1, lev%nnodes-1
           call lev%I(m)%setval(0.0_pfdp)
@@ -297,10 +313,10 @@ contains
 
        call pf_residual(pf, level_index, dt)
        call lev%qend%copy(lev%Q(lev%nnodes), flags=1)
-
+       if (pf%save_timings > 1) call pf_stop_timer(pf, T_SWEEP,level_index)
+       call call_hooks(pf, level_index, PF_POST_SWEEP)
     end do  !  End loop on sweeps
 
-    call end_timer(pf, TLEVEL+lev%index-1)
   end subroutine imk_actually_sweep
 
   subroutine imk_initialize(this, pf,level_index)
@@ -344,7 +360,7 @@ contains
 
     !>  Make space for temporary variables
     call lev%ulevel%factory%create_array(this%A, nnodes, &
-         lev%index,   lev%lev_shape)
+         level_index,   lev%lev_shape)
 
     do m = 1, nnodes
        call this%A(m)%setval(0.0_pfdp)
@@ -391,7 +407,7 @@ contains
     !  Propagate to get y=exp(Om)
     !prop needs e^{Q (omega)} and apply to Y
     if (this%debug) &
-         print*, 'level', lev%index, 'in evaluate ', m, '------------------'
+         print*, 'level', level_index, 'in evaluate ', m, '------------------'
 
     if (this%rk) then
        ! 't' in f_evals are meaningless since i have a time-independent matrix, A
@@ -401,24 +417,32 @@ contains
        end do
 
        call lev%Q(1)%copy(lev%q0, flags=1)
-       call this%f_eval(lev%Q(1), t, lev%index, this%A(1))
+       if (pf%save_timings > 1) call pf_start_timer(pf,T_FEVAL,level_index)       
+       call this%f_eval(lev%Q(1), t, level_index, this%A(1))
+       if (pf%save_timings > 1) call pf_stop_timer(pf,T_FEVAL,level_index)       
        ! commutator_p flags=1 hack copies Q(1)%y -> Q(1)%array
        ! all subsequent RK stages are done on Q(m)%array
        call this%commutator_p(this%A(1), lev%Q(1), lev%F(1,1), flags=1)
 
        call lev%Q(2)%axpy(1.0_pfdp, lev%Q(1))
        call lev%Q(2)%axpy(0.5_pfdp*dt, lev%F(1,1))
-       call this%f_eval(lev%Q(2), t, lev%index, this%A(2))
+       if (pf%save_timings > 1) call pf_start_timer(pf,T_FEVAL,level_index)       
+       call this%f_eval(lev%Q(2), t, level_index, this%A(2))
+       if (pf%save_timings > 1) call pf_stop_timer(pf,T_FEVAL,level_index)       
        call this%commutator_p(this%A(2), lev%Q(2), lev%F(2,1))
 
        call lev%Q(3)%axpy(1.0_pfdp, lev%Q(1))
        call lev%Q(3)%axpy(0.5_pfdp*dt, lev%F(2,1))
-       call this%f_eval(lev%Q(3), t, lev%index, this%A(3))
+       if (pf%save_timings > 1) call pf_start_timer(pf,T_FEVAL,level_index)       
+       call this%f_eval(lev%Q(3), t, level_index, this%A(3))
+       if (pf%save_timings > 1) call pf_stop_timer(pf,T_FEVAL,level_index)       
        call this%commutator_p(this%A(3), lev%Q(3), lev%F(3,1))
 
        call lev%Q(4)%axpy(1.0_pfdp, lev%Q(1))
        call lev%Q(4)%axpy(dt, lev%F(3,1))
-       call this%f_eval(lev%Q(4), t, lev%index, this%A(4))
+       if (pf%save_timings > 1) call pf_start_timer(pf,T_FEVAL,level_index)       
+       call this%f_eval(lev%Q(4), t, level_index, this%A(4))
+       if (pf%save_timings > 1) call pf_stop_timer(pf,T_FEVAL,level_index)       
        call this%commutator_p(this%A(4), lev%Q(4), lev%F(4,1))
 
        call lev%Q(5)%axpy(1.0_pfdp, lev%Q(1))
@@ -450,7 +474,9 @@ contains
        if (this%debug) call lev%Q(m)%eprint()
 
        !  Compute A(y,t)
-       call this%f_eval(lev%Q(m), t, lev%index, this%A(m))
+       if (pf%save_timings > 1) call pf_start_timer(pf,T_FEVAL,level_index)       
+       call this%f_eval(lev%Q(m), t, level_index, this%A(m))
+       if (pf%save_timings > 1) call pf_stop_timer(pf,T_FEVAL,level_index)       
        if (this%debug) print*, 'A'
        if (this%debug) call this%A(m)%eprint()
 

--- a/src/pf_interpolate.f90
+++ b/src/pf_interpolate.f90
@@ -35,7 +35,7 @@ contains
     c_lev => pf%levels(level_index-1) ! coarse level
 
     call call_hooks(pf, level_index, PF_PRE_INTERP_ALL)
-    call start_timer(pf, TINTERPOLATE + level_index - 1)
+    if (pf%save_timings > 1) call pf_start_timer(pf, T_INTERPOLATE,level_index)
     
     
     step = pf%state%step+1
@@ -96,7 +96,7 @@ contains
     deallocate(c_times,f_times)
 
 
-    call end_timer(pf, TINTERPOLATE + f_lev%index - 1)
+    if (pf%save_timings > 1) call pf_stop_timer(pf, T_INTERPOLATE,f_lev%index)
     call call_hooks(pf, f_lev%index, PF_POST_INTERP_ALL)
   end subroutine interpolate_time_space
 
@@ -112,7 +112,7 @@ contains
 
 
     call call_hooks(pf, f_lev%index, PF_PRE_INTERP_Q0)
-    call start_timer(pf, TINTERPOLATE + f_lev%index - 1)
+    if (pf%save_timings > 1) call pf_start_timer(pf, T_INTERPOLATE, f_lev%index )
 
 
     call c_lev%q0_delta%setval(0.0_pfdp,flags)
@@ -128,7 +128,7 @@ contains
     !> update fine inital condition
 
     call f_lev%q0%axpy(-1.0_pfdp, f_lev%q0_delta, flags)
-    call end_timer(pf, TINTERPOLATE + f_lev%index - 1)
+    if (pf%save_timings > 1) call pf_stop_timer(pf, T_INTERPOLATE,f_lev%index)
     call call_hooks(pf, f_lev%index, PF_POST_INTERP_Q0)
 
   end subroutine interpolate_q0
@@ -142,7 +142,7 @@ contains
     class(pf_level_t),  intent(inout) :: c_lev  !!  coarse level
     
     call call_hooks(pf, f_lev%index, PF_PRE_INTERP_Q0)
-    call start_timer(pf, TINTERPOLATE + f_lev%index - 1)
+    if (pf%save_timings > 1) call pf_start_timer(pf, T_INTERPOLATE, f_lev%index)
     
     call c_lev%q0_delta%setval(0.0_pfdp)
     call f_lev%q0_delta%setval(0.0_pfdp)
@@ -158,7 +158,7 @@ contains
     !> update fine inital condition
     call f_lev%qend%axpy(-1.0_pfdp, f_lev%q0_delta, flags=2)
 
-    call end_timer(pf, TINTERPOLATE + f_lev%index - 1)
+    if (pf%save_timings > 1) call pf_stop_timer(pf, T_INTERPOLATE,f_lev%index)
     call call_hooks(pf, f_lev%index, PF_POST_INTERP_Q0)
 
 

--- a/src/pf_misdcQ_oc_sweeper.f90
+++ b/src/pf_misdcQ_oc_sweeper.f90
@@ -88,7 +88,6 @@ contains
 
     lev => pf%levels(level_index)   !  Assign level pointer
 
-    call start_timer(pf, TLEVEL+lev%index-1)
     step = pf%state%step+1
 
     which = 0
@@ -109,8 +108,9 @@ contains
     tend = t0+dt
 
     do k = 1,nsweeps
-       pf%state%sweep=k
        call call_hooks(pf, level_index, PF_PRE_SWEEP)
+       call pf_start_timer(pf, T_SWEEP,level_index)
+       pf%state%sweep=k
 
        ! compute integrals and add fas correction
         if( sweep_y ) then
@@ -153,15 +153,15 @@ contains
        if (k .eq. 1) then
          if( sweep_y ) then
             call lev%Q(1)%copy(lev%q0, 1)
-            call this%f_eval(lev%Q(1), t0, lev%index, lev%F(1,1), 1, 1, 1, step)
-            call this%f_eval(lev%Q(1), t0, lev%index, lev%F(1,2), 2, 1, 1, step)
-            call this%f_eval(lev%Q(1), t0, lev%index, lev%F(1,3), 3, 1, 1, step)
+            call this%f_eval(lev%Q(1), t0, level_index, lev%F(1,1), 1, 1, 1, step)
+            call this%f_eval(lev%Q(1), t0, level_index, lev%F(1,2), 2, 1, 1, step)
+            call this%f_eval(lev%Q(1), t0, level_index, lev%F(1,3), 3, 1, 1, step)
          end if
          if( sweep_p ) then
             call lev%Q(Nnodes)%copy(lev%qend, 2)
-            call this%f_eval(lev%Q(Nnodes), tend, lev%index, lev%F(Nnodes,1), 1, 2, Nnodes, step)
-            call this%f_eval(lev%Q(Nnodes), tend, lev%index, lev%F(Nnodes,2), 2, 2, Nnodes, step)
-            call this%f_eval(lev%Q(Nnodes), tend, lev%index, lev%F(Nnodes,3), 3, 2, Nnodes, step)
+            call this%f_eval(lev%Q(Nnodes), tend, level_index, lev%F(Nnodes,1), 1, 2, Nnodes, step)
+            call this%f_eval(lev%Q(Nnodes), tend, level_index, lev%F(Nnodes,2), 2, 2, Nnodes, step)
+            call this%f_eval(lev%Q(Nnodes), tend, level_index, lev%F(Nnodes,3), 3, 2, Nnodes, step)
          end if
        end if ! k .eq. 1
 
@@ -180,7 +180,7 @@ contains
             !  Add the starting value
             call this%rhs%axpy(1.0_pfdp, lev%Q(1), 1)
 
-            call this%f_comp(lev%Q(m+1), t, dt*this%QtilI(m,m+1), this%rhs, lev%index, lev%F(m+1,2), 2, 1)
+            call this%f_comp(lev%Q(m+1), t, dt*this%QtilI(m,m+1), this%rhs, level_index, lev%F(m+1,2), 2, 1)
 
             !  Now we need to do the final subtraction for the f3 piece
             call this%rhs%copy(lev%Q(m+1), 1)
@@ -189,9 +189,9 @@ contains
             end do
 
             call this%rhs%axpy(-1.0_pfdp, this%I3(m), 1)
-            call this%f_comp(lev%Q(m+1), t, dt*this%QtilI(m,m+1), this%rhs, lev%index, lev%F(m+1,3), 3, 1)
-            call this%f_eval(lev%Q(m+1), t, lev%index, lev%F(m+1,1), 1, 1, m+1, step)
-            call this%f_eval(lev%Q(m+1), t, lev%index, lev%F(m+1,2), 2, 1, m+1, step)
+            call this%f_comp(lev%Q(m+1), t, dt*this%QtilI(m,m+1), this%rhs, level_index, lev%F(m+1,3), 3, 1)
+            call this%f_eval(lev%Q(m+1), t, level_index, lev%F(m+1,1), 1, 1, m+1, step)
+            call this%f_eval(lev%Q(m+1), t, level_index, lev%F(m+1,2), 2, 1, m+1, step)
          end do
          !call pf_residual(pf, level_index, dt, 1)
          call lev%qend%copy(lev%Q(lev%nnodes), 1)
@@ -211,7 +211,7 @@ contains
             !  Add the starting value
             call this%rhs%axpy(1.0_pfdp, lev%Q(Nnodes), 2)
 
-            call this%f_comp(lev%Q(m), t, dt*this%QtilI(Nnodes-m,Nnodes-m+1), this%rhs, lev%index, lev%F(m,2), 2, 2)
+            call this%f_comp(lev%Q(m), t, dt*this%QtilI(Nnodes-m,Nnodes-m+1), this%rhs, level_index, lev%F(m,2), 2, 2)
 
             !  Now we need to do the final subtraction for the f3 piece
             call this%rhs%copy(lev%Q(m), 2)
@@ -221,9 +221,9 @@ contains
 
             call this%rhs%axpy(-1.0_pfdp, this%I3(m), 2)
 
-            call this%f_comp(lev%Q(m), t, dt*this%QtilI(Nnodes-m,Nnodes-m+1), this%rhs, lev%index, lev%F(m,3), 3, 2)
-            call this%f_eval(lev%Q(m), t, lev%index, lev%F(m,1), 1, 2, m, step)
-            call this%f_eval(lev%Q(m), t, lev%index, lev%F(m,2), 2, 2, m, step)
+            call this%f_comp(lev%Q(m), t, dt*this%QtilI(Nnodes-m,Nnodes-m+1), this%rhs, level_index, lev%F(m,3), 3, 2)
+            call this%f_eval(lev%Q(m), t, level_index, lev%F(m,1), 1, 2, m, step)
+            call this%f_eval(lev%Q(m), t, level_index, lev%F(m,2), 2, 2, m, step)
          end do
          !call pf_residual(pf, level_index, dt, 2)
          call lev%q0%copy(lev%Q(1), 2)
@@ -239,6 +239,8 @@ contains
          call pf_stop(__FILE__,__LINE__,'invalid sweep')         
        end if
        ! done
+       call pf_stop_timer(pf, T_SWEEP,level_index)
+
        call call_hooks(pf, level_index, PF_POST_SWEEP)
     end do ! k=1,nsweeps
   end subroutine misdcQ_oc_sweep
@@ -284,10 +286,10 @@ contains
     this%QdiffI = lev%sdcmats%qmat-this%QtilI
 
     !>  Make space for rhs
-    call lev%ulevel%factory%create_single(this%rhs, lev%index, lev%lev_shape)
+    call lev%ulevel%factory%create_single(this%rhs, level_index, lev%lev_shape)
 
     !>  Make space for extra integration piece
-    call lev%ulevel%factory%create_array(this%I3,lev%nnodes-1,lev%index,lev%lev_shape)
+    call lev%ulevel%factory%create_array(this%I3,lev%nnodes-1,level_index,lev%lev_shape)
 
   end subroutine misdcQ_oc_initialize
 
@@ -369,9 +371,9 @@ contains
     mystep = 1
     if(present(step)) mystep = step
 
-    call this%f_eval(lev%Q(m), t, lev%index, lev%F(m,1), 1, which, m, step)
-    call this%f_eval(lev%Q(m), t, lev%index, lev%F(m,2), 2, which, m, step)
-    call this%f_eval(lev%Q(m), t, lev%index, lev%F(m,3), 3, which, m, step)
+    call this%f_eval(lev%Q(m), t, level_index, lev%F(m,1), 1, which, m, step)
+    call this%f_eval(lev%Q(m), t, level_index, lev%F(m,2), 2, which, m, step)
+    call this%f_eval(lev%Q(m), t, level_index, lev%F(m,3), 3, which, m, step)
   end subroutine misdcQ_oc_evaluate
 
 

--- a/src/pf_misdc_sweeper.f90
+++ b/src/pf_misdc_sweeper.f90
@@ -66,7 +66,7 @@ contains
     class(pf_encap_t), allocatable :: S3(:)
     class(pf_encap_t), allocatable :: rhs
 
-    call start_timer(pf, TLEVEL+lev%index-1)
+    if (pf%save_timings > 1) call pf_start_timer(pf, T_SWEEP,lev%index)
     
     ! compute integrals and add fas correction
     do m = 1, lev%nnodes-1
@@ -116,7 +116,7 @@ contains
     ! done
     call lev%ulevel%factory%destroy_single(rhs, lev%index,  lev%lev_shape)
 
-    call end_timer(pf, TLEVEL+lev%index-1)
+    if (pf%save_timings > 1) call pf_stop_timer(pf, T_SWEEP,lev%index)
 
   end subroutine misdc_sweep
      

--- a/src/pf_parallel_oc.f90
+++ b/src/pf_parallel_oc.f90
@@ -38,7 +38,7 @@ contains
        if(flags(1)==0) which = 0   ! sweep forward and backward simultaneously on two components, communication only forwards
     end if
     call call_hooks(pf, 1, PF_PRE_PREDICTOR)
-    call start_timer(pf, TPREDICTOR)
+    if (pf%save_timings > 1) call pf_start_timer(pf, T_PREDICTOR)
 
     if (pf%debug) print*, 'DEBUG --', pf%rank, 'beginning predictor'
 
@@ -195,7 +195,7 @@ contains
 
   end if
 
-    call end_timer(pf, TPREDICTOR)
+    if (pf%save_timings > 1) call pf_stop_timer(pf, T_PREDICTOR)
     call call_hooks(pf, -1, PF_POST_PREDICTOR)
 
     pf%state%iter   = 0
@@ -330,8 +330,7 @@ contains
 
     logical :: converged, qbroadcast
     logical :: did_post_step_hook
-
-    call start_timer(pf, TTOTAL)
+    if (pf%save_timings > 0) call pf_start_timer(pf, T_TOTAL)
 
     which = 1
     if (present(flags)) which = flags
@@ -384,7 +383,7 @@ contains
     !pf%state%pfblock = k ! has to be set in pf_optimization_flex to current step
                           ! this is relevant for save_residuals
     do j = 1, pf%niters
-      call start_timer(pf, TITERATION)
+      if (pf%save_timings > 1) call pf_start_timer(pf, T_ITERATION)
       call call_hooks(pf, -1, PF_PRE_ITERATION)
 
       pf%state%iter = j
@@ -396,19 +395,22 @@ contains
       !  Check for convergence
       call pf_check_convergence_oc(pf, pf%state%finest_level, send_tag=1111*k+j, flags=dir)
 
+      if (pf%save_timings > 1) call pf_stop_timer(pf, T_ITERATION)
       call call_hooks(pf, -1, PF_POST_ITERATION)
-      call end_timer(pf, TITERATION)
 
       !  If we are converged, exit block
-      if (pf%state%status == PF_STATUS_CONVERGED)  exit
+      if (pf%state%status == PF_STATUS_CONVERGED) then
+         call call_hooks(pf, -1, PF_POST_CONVERGENCE)
+         exit
+      end if
+      
     end do  !  Loop over the iteration in this block
-    call call_hooks(pf, -1, PF_POST_CONVERGENCE)
     pf%state%itcnt = pf%state%itcnt + pf%state%iter
     call call_hooks(pf, -1, PF_POST_STEP)
 
     
-!    call pf_dump_results(pf)
-    call end_timer(pf, TTOTAL)
+    !  call pf_dump_results(pf)
+    if (pf%save_timings > 0) call pf_stop_timer(pf, T_TOTAL)
   end subroutine pf_pfasst_block_oc
 
   subroutine pf_v_cycle_oc(pf, iteration, t0, dt, level_index_c,level_index_f, flags)

--- a/src/pf_restrict.f90
+++ b/src/pf_restrict.f90
@@ -43,7 +43,7 @@ contains
     if(present(mystep)) step = mystep
     
     call call_hooks(pf, level_index, PF_PRE_RESTRICT_ALL)
-    call start_timer(pf, TRESTRICT + level_index - 1)
+    if (pf%save_timings > 1) call pf_start_timer(pf, T_RESTRICT, level_index)
     
 
     allocate(c_times(c_lev%nnodes),stat=ierr)
@@ -98,7 +98,7 @@ contains
        
     end if
 
-    call end_timer(pf, TRESTRICT + level_index - 1)
+    if (pf%save_timings > 1) call pf_stop_timer(pf, T_RESTRICT,level_index)
     call call_hooks(pf, level_index, PF_POST_RESTRICT_ALL)
 
     deallocate(c_times)

--- a/src/pf_utils.f90
+++ b/src/pf_utils.f90
@@ -23,7 +23,7 @@ contains
     integer :: m
     type(pf_level_t), pointer   :: lev
     
-    call start_timer(pf, TRESIDUAL)
+    if (pf%save_timings > 1) call pf_start_timer(pf, T_RESIDUAL,level_index)
 
     lev => pf%levels(level_index)
     call lev%ulevel%sweeper%residual(pf,level_index, dt, flag)
@@ -53,7 +53,8 @@ contains
 
     call pf_set_resid(pf,lev%index,lev%residual)
 
-    call end_timer(pf, TRESIDUAL)
+    if (pf%save_timings > 1) call pf_stop_timer(pf, T_RESIDUAL,level_index)
+
 
   end subroutine pf_residual
 
@@ -264,5 +265,40 @@ contains
       end do
     end do
   end subroutine pf_apply_mat_backward
+  
+  function convert_logical(q) result(q_string)
+    logical,intent(in) :: q  ! true or false
+    character(len=5)::  q_string
+    if (q) then
+       q_string=' true'
+    else
+       q_string='false'
+    end if
+  end function convert_logical
+
+  function convert_int_array(q,n) result(q_string)
+    integer,intent(in) :: n     ! length of array
+    integer,intent(in) :: q(n)  ! integer array
+    character(len=15)::  q_string
+
+    character(len=15)::  f_string  !  format string
+    integer i
+    write(f_string,"(*(G0,:,','))") q
+    q_string=adjustr('['//trim(f_string)//']')
+
+  end function convert_int_array
+
+  function convert_real_array(q,n) result(q_string)
+    integer,intent(in) :: n     ! length of array
+    real(pfdp) , intent(in) :: q(n)  ! real array
+    character(len=128)::  q_string
+
+    character(len=128)::  f_string  !  format string
+    integer i
+    write(f_string,"(*(e12.6,:,','))") q
+    q_string=adjustl('['//trim(f_string)//']')
+
+  end function convert_real_array
+  
   
 end module pf_mod_utils

--- a/test/EXP_adv_diff_fft/1d/multi_level.nml
+++ b/test/EXP_adv_diff_fft/1d/multi_level.nml
@@ -28,7 +28,6 @@
      Vcycle=.TRUE.
 
      save_residuals=.false.
-     save_timings=.false.
 
 /
 

--- a/test/EXP_adv_diff_fft/1d/sdc.nml
+++ b/test/EXP_adv_diff_fft/1d/sdc.nml
@@ -21,7 +21,6 @@
      nsweeps_pred= 1 
      nsweeps= 1
      save_residuals=.false.
-     save_timings=.false.
      
 /
 

--- a/test/adv_diff_fft/1d/multi_level.nml
+++ b/test/adv_diff_fft/1d/multi_level.nml
@@ -4,7 +4,7 @@
 
 !  These are internal pfasst variables that must be set
 &PF_PARAMS
-    nlevels  = 3   !  must be set
+    nlevels  = 2   !  must be set
 
     niters = 10   !  default is 5
     nnodes =     3 5 9
@@ -17,8 +17,8 @@
     qtype  = 1   
    
      !  optional variables to control termination  (defaults are 0.0)
-     abs_res_tol = 1.d-13
-     rel_res_tol = 1.d-13
+     abs_res_tol = 0.d-13
+     rel_res_tol = 0.d-13
 
 
      !  Variable which determine how the predictor runs  (default is .false. and .true.)
@@ -30,7 +30,7 @@
 
 
      save_residuals=.false.
-     save_timings=.false.
+     save_timings=0
      use_Sform=.true.
 /
 
@@ -41,8 +41,8 @@
     nu = 0.02
     v=1.0
 
-    Tfin = 0.9
-    nsteps = 16
+    Tfin = 0.4
+    nsteps = 48
 
     imex_stat=2
 

--- a/test/adv_diff_fft/1d/sdc.nml
+++ b/test/adv_diff_fft/1d/sdc.nml
@@ -13,14 +13,14 @@
     nsweeps= 1 
 
     !  These are internal pfasst variables that can be reset
-    niters = 9   !  default is 5
+    niters = 20   !  default is 5
  
     !  Type of quadrature nodes (default is 1=Gauss-Lobatto)
     qtype   = 1   
    
      !  optional variables to control termination  (defaults are 0.0)
-     abs_res_tol = 1.d-13
-     rel_res_tol = 1.d-13
+     abs_res_tol = -1.d-13
+     rel_res_tol = -1.d-13
 
      !  Variable which determine how the predictor runs  (default is .false. and .true.)
      Pipeline_pred =  .true.
@@ -30,7 +30,6 @@
      !  Variable to tell if Vcycling will be done.  Here we do pipelining
      Vcycle=.false.
      save_residuals=.false.
-     save_timings=.false.
 /
 
 !  Now define the local variables you need

--- a/test/adv_diff_fft/2d/multi_level.nml
+++ b/test/adv_diff_fft/2d/multi_level.nml
@@ -26,7 +26,6 @@
      !  Variable to tell if Vcycling will be done.  Here PFASST vcycles
      Vcycle=.TRUE.
      save_residuals=.false.
-     save_timings=.false.
      
 /
 

--- a/test/adv_diff_fft/2d/sdc.nml
+++ b/test/adv_diff_fft/2d/sdc.nml
@@ -29,7 +29,6 @@
      !  Variable to tell if Vcycling will be done.  Here we do pipelining
      Vcycle=.false.
      save_residuals=.false.
-     save_timings=.false.
      
 /
 

--- a/test/imk/facke.nml
+++ b/test/imk/facke.nml
@@ -1,29 +1,28 @@
 &pf_params
-	nlevels = 1
+	nlevels = 2
 	niters = 20
-	nnodes = 5 
-	nsweeps_pred = 1 
-	nsweeps = 1 
+	nnodes = 3 5 
+	nsweeps_pred =1 1 
+	nsweeps = 1 1 
 	qtype = 1 
-	echo_timings = .true.
 	abs_res_tol = 1e-13
-	rel_res_tol = 1e-13
+	rel_res_tol = 0e-13
 	pipeline_pred = .true.
 	pfasst_pred = .true.
-	vcycle = .false.
+	vcycle = .true.
 /
 
 &params
 	Nprob=2
-	nterms=12
+	nterms=2 12
 	fbase = "./output"
 	tfin = 0.05
-	nsteps = 128
+	nsteps = 32
 	exptol = 1.d-15
 	nparticles = 20
 	save_solutions = .true.
 	toda_periodic = .true.
-	use_sdc = .false.
-	Znuc=0.1
-	E0=0.01
+	use_sdc = .true.
+	Znuc=0.5
+	E0=0.05
 /

--- a/test/imk/facke_multi.nml
+++ b/test/imk/facke_multi.nml
@@ -5,7 +5,6 @@
 	nsweeps_pred = 1 1
 	nsweeps = 1 1
 	qtype = 1 
-	echo_timings = .true.
 	abs_res_tol = 1e-12
 	rel_res_tol = 1e-12
 	pipeline_pred = .true.

--- a/test/imk/probin.nml
+++ b/test/imk/probin.nml
@@ -5,7 +5,6 @@
 	nsweeps_pred = 1 1 1
 	nsweeps = 1 1 1
 	qtype = 1
-	echo_timings = .false.
 	abs_res_tol = 1e-12
 	rel_res_tol = 1e-12
 	pipeline_pred = .true.

--- a/test/imk/src/hooks.f90
+++ b/test/imk/src/hooks.f90
@@ -48,7 +48,7 @@ contains
        print *,q_ex
        errd = maxval(abs(q_diag-q_ex))
        
-       print *,'Rank ',pf%rank,'Nsteps ',pf%state%step+1,' Iter ',pf%state%iter,' error at end=',errd, 'totTime=',pf%runtimes(1), 'Nnodes=',pf%nnodes(level_index), 'qtype=',pf%qtype
+       print *,'Rank ',pf%rank,'Nsteps ',pf%state%step+1,' Iter ',pf%state%iter,' error at end=',errd, 'totTime=',pf%pf_runtimes%t_total, 'Nnodes=',pf%nnodes(level_index), 'qtype=',pf%qtype
     endif
     
     deallocate(yexact%array)

--- a/test/imk/toda.nml
+++ b/test/imk/toda.nml
@@ -6,7 +6,6 @@
 	nsweeps_pred = 1 1
 	nsweeps = 1 1
 	qtype = 1
-	echo_timings = .false.
 	abs_res_tol = 1.0e-14
 	rel_res_tol = 1.0e-14
 	pipeline_pred = .false.

--- a/test/magpicard/facke.nml
+++ b/test/magpicard/facke.nml
@@ -5,7 +5,6 @@
 	nsweeps_pred = 1 
 	nsweeps = 1 
 	qtype = 5 
-	echo_timings = .false.
 	abs_res_tol = 1e-13
 	rel_res_tol = 1e-13
 	pipeline_pred = .true.

--- a/test/magpicard/probin.nml
+++ b/test/magpicard/probin.nml
@@ -5,7 +5,6 @@
 	nsweeps_pred = 1 1
 	nsweeps = 1 1
 	qtype = 5 
-	echo_timings = .false.
 	abs_res_tol = 0e-13
 	rel_res_tol = 0e-13
 	pipeline_pred = .true.

--- a/test/magpicard/src/hooks.f90
+++ b/test/magpicard/src/hooks.f90
@@ -35,7 +35,7 @@ contains
        q_diag = real(qend%flatarray(1:400:21))
        errd = maxval(abs(q_diag-q_ex))
       
-       print *,'Rank ',pf%rank,'Nsteps ',pf%state%step+1,' Iter ',pf%state%iter,' error at end=',errd, 'totTime=',pf%runtimes(1),'Ord=',magnus_order, 'Nnodes=',nnodes(1), 'qtype=',pf%qtype
+       print *,'Rank ',pf%rank,'Nsteps ',pf%state%step+1,' Iter ',pf%state%iter,' error at end=',errd, 'totTime=',pf%pf_runtimes%t_total,'Ord=',magnus_order, 'Nnodes=',nnodes(1), 'qtype=',pf%qtype
     endif
 
   end subroutine echo_error

--- a/test/magpicard/toda.nml
+++ b/test/magpicard/toda.nml
@@ -5,7 +5,6 @@
 	nsweeps_pred = 1
 	nsweeps = 1
 	qtype = 5
-	echo_timings = .false.
 	abs_res_tol = 1e-12
 	rel_res_tol = 1e-12
 	pipeline_pred = .true.

--- a/test/nagumo/pfasst.nml
+++ b/test/nagumo/pfasst.nml
@@ -15,6 +15,5 @@
 
      PFASST_pred = .false.
 
-     echo_timings = .false.
 
 /

--- a/test/nagumo/probin.nml
+++ b/test/nagumo/probin.nml
@@ -15,9 +15,7 @@
 
      PFASST_pred = .false.
 
-     echo_timings = .false.
      save_residuals = .false.
-     save_timings = .false.
 
 /
 

--- a/test/nagumo/src/main_split.f90
+++ b/test/nagumo/src/main_split.f90
@@ -68,8 +68,6 @@ program main
   call pf_mpi_create(comm, MPI_COMM_WORLD)
   call pf_pfasst_create(pf, comm,  fname=pfasst_nml)
   
-  pf%echo_timings = .false.
-       
   do l = 1, pf%nlevels
        pf%levels(l)%nnodes = nnodes(l)
 


### PR DESCRIPTION
This merge replaces the old timer routines and data structures.  Some timers were added such as those for f_eval and f_comp.  A json file is now output by each processor containing all the timing info to ease input into python.

Users should delete any echo_timings in input files and update save_timings to be an integer
0-no timing
1-just the total time is saved
2-all timers are saved
3-all timers are saved and much info echoed to screen (the old echo_timings)