### PR TITLE
Deallocate restrict workspace when destroying level

### DIFF
--- a/src/pf_pfasst.f90
+++ b/src/pf_pfasst.f90
@@ -301,6 +301,10 @@ contains
        call lev%ulevel%factory%destroy_array(lev%cf_delta)
        lev%interp_workspace_allocated =.false.
     endif
+    if (lev%restrict_workspace_allocated   .eqv. .true.) then
+        call lev%ulevel%factory%destroy_array(lev%f_encap_array_c)
+        lev%restrict_workspace_allocated =.false.
+    endif
     call lev%ulevel%factory%destroy_array(lev%Q)
     call lev%ulevel%factory%destroy_array(lev%R)
     call lev%ulevel%factory%destroy_single(lev%qend)


### PR DESCRIPTION
This does not show up on Valgrind results for LibPFASST (tested on EX2), but when delegating the allocation/deallocation calls of EX2 to C it will show that the memory isn't freed.