### PR TITLE
Add option for compiling with gcc 10

### DIFF
--- a/Makefile.local
+++ b/Makefile.local
@@ -9,5 +9,10 @@ FFLAGS = -Ibuild -Jinclude -cpp -ffree-line-length-none
 ifeq ($(DEBUG),TRUE)
 FFLAGS += -fcheck=all -fbacktrace -g -ffpe-trap=invalid,zero,overflow -fbounds-check -fimplicit-none -ffree-line-length-none
 else
-FFLAGS += -O3 
+FFLAGS += -O3
+endif
+
+ifeq ($(GCC10),TRUE)
+FFLAGS += -fallow-argument-mismatch
+F77FLAGS += -fallow-argument-mismatch
 endif

--- a/Makefile.local
+++ b/Makefile.local
@@ -12,6 +12,7 @@ else
 FFLAGS += -O3
 endif
 
+F77FLAGS =
 ifeq ($(GCC10),TRUE)
 FFLAGS += -fallow-argument-mismatch
 F77FLAGS += -fallow-argument-mismatch

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -40,10 +40,10 @@ build/%.o: %.f
 	@mkdir -p build
 	@mkdir -p include
 ifeq ($(MKVERBOSE),TRUE)
-	$(FC)  -c -w $< $(OUTPUT_OPTION)
+	$(FC) $(F77FLAGS) -c -w $< $(OUTPUT_OPTION)
 else
 	@echo "Building $<..."
-	@$(FC)  -c -w $< $(OUTPUT_OPTION)
+	@$(FC) $(F77FLAGS) -c -w $< $(OUTPUT_OPTION)
 endif
 
 .PHONY: clean depend


### PR DESCRIPTION
gcc 10 makes argument type mismatches errors, which is preventing fftpack and the MPI calls (at least with mpich) from compiling. Adding the flag [-fallow-argument-mismatch](https://gcc.gnu.org/onlinedocs/gfortran/Fortran-Dialect-Options.html) degrades it to a warning, but, since it's a new flag, using it in previous versions will cause an error.

With the change, calling make with GCC10=TRUE adds the flag at the proper locations.