### PR TITLE
Add option for extra Fortran compile flags

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -8,10 +8,10 @@ vpath %.f   $(VPATHS)
 
 $(EXE): $(OBJ)
 ifeq ($(MKVERBOSE),TRUE)
-	$(FC) $(FFLAGS)  $^ $(OUTPUT_OPTION) $(LDFLAGS)
+	$(FC) $(FFLAGS) $(FFLAGS_EXTRA)  $^ $(OUTPUT_OPTION) $(LDFLAGS)
 else
 	@echo "Linking..."
-	@$(FC) $(FFLAGS)  $^ $(OUTPUT_OPTION) $(LDFLAGS)
+	@$(FC) $(FFLAGS) $(FFLAGS_EXTRA)  $^ $(OUTPUT_OPTION) $(LDFLAGS)
 endif
 
 build/%.o build/%.mod: %.f90
@@ -19,10 +19,10 @@ build/%.o build/%.mod: %.f90
 	@mkdir -p include
 
 ifeq ($(MKVERBOSE),TRUE)
-	$(FC) $(FFLAGS) -c  $< $(OUTPUT_OPTION)
+	$(FC) $(FFLAGS) $(FFLAGS_EXTRA) -c  $< $(OUTPUT_OPTION)
 else
 	@echo "Building $<..."
-	@$(FC) $(FFLAGS) -c  $< $(OUTPUT_OPTION)
+	@$(FC) $(FFLAGS) $(FFLAGS_EXTRA) -c  $< $(OUTPUT_OPTION)
 endif
 
 build/%.o: %.c
@@ -40,10 +40,10 @@ build/%.o: %.f
 	@mkdir -p build
 	@mkdir -p include
 ifeq ($(MKVERBOSE),TRUE)
-	$(FC)  -c -w $< $(OUTPUT_OPTION)
+	$(FC) $(FFLAGS_EXTRA) -c -w $< $(OUTPUT_OPTION)
 else
 	@echo "Building $<..."
-	@$(FC)  -c -w $< $(OUTPUT_OPTION)
+	@$(FC) $(FFLAGS_EXTRA) -c -w $< $(OUTPUT_OPTION)
 endif
 
 .PHONY: clean depend


### PR DESCRIPTION
This is intended to fix the same issue as #43, but in a more flexible way, since it allows command-line appending of any Fortran flags without overriding LibPFASST's default. 

Note: The recently released mpich 3.4 enables -fallow-argument-mismatch on Fortran by default, but it's still necessary to manually add it when pairing gcc 10 with earlier mpich versions.